### PR TITLE
feat: move workspaces under .amux/workspaces

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,18 +150,17 @@ project-root/
 │   ├── config.yaml            # Project configuration
 │   ├── sessions/              # Session metadata
 │   │   └── session-*.yaml     # Individual session files
-│   └── workspaces/            # Workspace metadata
-│       └── workspace-*.yaml   # Individual workspace files
-├── .worktrees/                # Git worktrees
-│   └── workspace-{id}/        # Isolated workspace
-│       ├── .amux/
-│       │   ├── workspace.yaml # Workspace metadata
-│       │   └── context/       # Working context
-│       │       ├── background.md
-│       │       ├── plan.md
-│       │       ├── working-log.md
-│       │       └── results-summary.md
-│       └── [project files]    # Actual code
+│   └── workspaces/            # Workspace storage
+│       ├── workspace-*.yaml   # Workspace metadata files
+│       └── workspace-{id}/    # Git worktrees (isolated workspaces)
+│           ├── .amux/
+│           │   ├── workspace.yaml # Workspace metadata
+│           │   └── context/       # Working context
+│           │       ├── background.md
+│           │       ├── plan.md
+│           │       ├── working-log.md
+│           │       └── results-summary.md
+│           └── [project files]    # Actual code
 └── [main project files]       # Original repository
 
 ```

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -97,7 +97,7 @@ func addToGitignore(projectRoot string) error {
 	}
 
 	// Append .amux entries
-	entries := "\n# Amux\n.amux/\n.worktrees/\n"
+	entries := "\n# Amux\n.amux/\n"
 
 	file, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -66,11 +66,10 @@ func (m *Manager) Create(opts CreateOptions) (*Workspace, error) {
 	}
 
 	// Create workspace directory path
-	workspacePath := filepath.Join(m.configManager.GetProjectRoot(), ".worktrees", id)
+	workspacePath := filepath.Join(m.workspacesDir, id)
 
-	// Ensure the .worktrees directory exists
-	worktreesDir := filepath.Dir(workspacePath)
-	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+	// Ensure the workspaces directory exists
+	if err := os.MkdirAll(m.workspacesDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create worktrees directory: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Move workspace storage from  to 
- Consolidate all workspace-related files in one location
- Simplify project structure

## Changes

- Updated workspace manager to create git worktrees in 
- Removed  from gitignore template
- Updated architecture documentation
- Added  to markdown lint ignores

## Breaking Changes

⚠️ **BREAKING**: Existing workspaces in  will not be recognized. Users will need to recreate their workspaces.

Since we're in an early phase, no migration path is provided.

## Testing

- All tests pass
- Created and removed test workspace successfully
- Verified workspace is created in new location

Closes #3