### PR TITLE
fix: resolve linting errors detected by golangci-lint v2

### DIFF
--- a/cmd/amux/main.go
+++ b/cmd/amux/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the amux CLI application.
 package main
 
 import (

--- a/internal/adapters/tmux/adapter.go
+++ b/internal/adapters/tmux/adapter.go
@@ -1,3 +1,4 @@
+// Package tmux provides a tmux adapter for terminal multiplexing.
 package tmux
 
 import (

--- a/internal/adapters/tmux/mock.go
+++ b/internal/adapters/tmux/mock.go
@@ -117,9 +117,10 @@ func (m *MockAdapter) SendKeys(sessionName, keys string) error {
 	session.output = append(session.output, keys)
 
 	// Simulate some common command outputs
-	if keys == "echo 'Hello from tmux'" {
+	switch keys {
+	case "echo 'Hello from tmux'":
 		session.output = append(session.output, "Hello from tmux")
-	} else if keys == "echo $TEST_VAR1" {
+	case "echo $TEST_VAR1":
 		if val, ok := session.environment["TEST_VAR1"]; ok {
 			session.output = append(session.output, val)
 		}

--- a/internal/cli/commands/agent.go
+++ b/internal/cli/commands/agent.go
@@ -1,3 +1,4 @@
+// Package commands implements the CLI commands for Amux.
 package commands
 
 import (

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -49,7 +49,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Check if already initialized
 	if configManager.IsInitialized() && !forceInit {
-		return fmt.Errorf("Amux already initialized. Use --force to reinitialize")
+		return fmt.Errorf("amux already initialized. Use --force to reinitialize")
 	}
 
 	// Create default configuration
@@ -103,7 +103,11 @@ func addToGitignore(projectRoot string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	_, err = file.WriteString(entries)
 	return err

--- a/internal/cli/commands/root.go
+++ b/internal/cli/commands/root.go
@@ -63,9 +63,7 @@ func init() {
 }
 
 // Execute runs the root command
-
 func Execute() error {
-
 	return rootCmd.Execute()
 
 }

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -423,7 +423,7 @@ func getWorkspaceManager() (*workspace.Manager, error) {
 
 	if !configManager.IsInitialized() {
 
-		return nil, fmt.Errorf("Amux not initialized. Run 'amux init' first")
+		return nil, fmt.Errorf("amux not initialized. Run 'amux init' first")
 
 	}
 

--- a/internal/cli/ui/colors.go
+++ b/internal/cli/ui/colors.go
@@ -1,34 +1,42 @@
+// Package ui provides UI styling and output functions for the CLI.
 package ui
 
 import "github.com/charmbracelet/lipgloss"
 
 var (
-
-	// Color styles
-
+	// ErrorStyle is the style for error messages
 	ErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 
+	// SuccessStyle is the style for success messages
 	SuccessStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00"))
 
+	// InfoStyle is the style for informational messages
 	InfoStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#0099FF"))
 
+	// WarningStyle is the style for warning messages
 	WarningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFAA00"))
 
+	// DimStyle is the style for dimmed text
 	DimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
 
+	// BoldStyle is the style for bold text
 	BoldStyle = lipgloss.NewStyle().Bold(true)
 
+	// HeaderStyle is the style for headers
 	HeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFFFFF"))
 
-	// Icons
-
+	// CaveIcon is the icon for caves/workspaces
 	CaveIcon = "🕳️"
 
+	// SuccessIcon is the icon for success messages
 	SuccessIcon = "✅"
 
+	// ErrorIcon is the icon for error messages
 	ErrorIcon = "❌"
 
+	// InfoIcon is the icon for informational messages
 	InfoIcon = "ℹ️"
 
+	// WarningIcon is the icon for warning messages
 	WarningIcon = "⚠️"
 )

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -8,26 +8,28 @@ import (
 	"github.com/aki/amux/internal/core/workspace"
 )
 
-// Print functions for consistent output
-
+// Error prints an error message with formatting
 func Error(format string, args ...interface{}) {
 
 	fmt.Fprintf(os.Stderr, "%s %s\n", ErrorIcon, ErrorStyle.Render(fmt.Sprintf(format, args...)))
 
 }
 
+// Success prints a success message with formatting
 func Success(format string, args ...interface{}) {
 
 	fmt.Printf("%s %s\n", SuccessIcon, SuccessStyle.Render(fmt.Sprintf(format, args...)))
 
 }
 
+// Info prints an informational message with formatting
 func Info(format string, args ...interface{}) {
 
 	fmt.Printf("%s %s\n", InfoIcon, InfoStyle.Render(fmt.Sprintf(format, args...)))
 
 }
 
+// Warning prints a warning message with formatting
 func Warning(format string, args ...interface{}) {
 
 	fmt.Printf("%s %s\n", WarningIcon, WarningStyle.Render(fmt.Sprintf(format, args...)))
@@ -35,7 +37,6 @@ func Warning(format string, args ...interface{}) {
 }
 
 // PrintWorkspace displays a single workspace with formatting
-
 func PrintWorkspace(w *workspace.Workspace) {
 
 	// Calculate age from last modified time
@@ -134,7 +135,6 @@ func PrintWorkspaceDetails(w *workspace.Workspace) {
 }
 
 // FormatTime formats a time for display
-
 func FormatTime(t time.Time) string {
 
 	if t.IsZero() {

--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -1,3 +1,4 @@
+// Package agent provides AI agent configuration and management.
 package agent
 
 import (

--- a/internal/core/common/idmap.go
+++ b/internal/core/common/idmap.go
@@ -1,3 +1,4 @@
+// Package common provides shared utilities for Amux core functionality.
 package common
 
 import (

--- a/internal/core/config/manager.go
+++ b/internal/core/config/manager.go
@@ -1,3 +1,4 @@
+// Package config provides configuration management for Amux projects.
 package config
 
 import (
@@ -9,7 +10,9 @@ import (
 )
 
 const (
-	AmuxDir    = ".amux"
+	// AmuxDir is the directory name for Amux metadata
+	AmuxDir = ".amux"
+	// ConfigFile is the filename for the Amux configuration
 	ConfigFile = "config.yaml"
 )
 
@@ -32,7 +35,7 @@ func (m *Manager) Load() (*Config, error) {
 	data, err := os.ReadFile(m.configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("Amux not initialized. Run 'amux init' first")
+			return nil, fmt.Errorf("amux not initialized. Run 'amux init' first")
 		}
 		return nil, fmt.Errorf("failed to read config: %w", err)
 	}

--- a/internal/core/context/manager.go
+++ b/internal/core/context/manager.go
@@ -1,3 +1,4 @@
+// Package context provides working context management for AI agents.
 package context
 
 import (
@@ -8,13 +9,16 @@ import (
 )
 
 const (
-	// Context directory name within workspace
+	// ContextDir is the directory name for working context within workspace
 	ContextDir = ".amux/context"
 
-	// Context file names
-	BackgroundFile     = "background.md"
-	PlanFile           = "plan.md"
-	WorkingLogFile     = "working-log.md"
+	// BackgroundFile contains project requirements and constraints
+	BackgroundFile = "background.md"
+	// PlanFile contains implementation approach and task breakdown
+	PlanFile = "plan.md"
+	// WorkingLogFile contains real-time progress and decision records
+	WorkingLogFile = "working-log.md"
+	// ResultsSummaryFile contains final outcomes for review
 	ResultsSummaryFile = "results-summary.md"
 )
 
@@ -200,16 +204,20 @@ func (m *Manager) AppendToWorkingLog(entry string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open working log: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close working log: %w", cerr)
+		}
+	}()
 
 	// Add timestamp and entry
 	timestamp := time.Now().Format("15:04:05")
 	content := fmt.Sprintf("\n### [%s] %s\n", timestamp, entry)
 
-	if _, err := file.WriteString(content); err != nil {
+	if _, err = file.WriteString(content); err != nil {
 		return fmt.Errorf("failed to write to working log: %w", err)
 	}
 
-	return nil
+	return err
 
 }

--- a/internal/core/git/operations.go
+++ b/internal/core/git/operations.go
@@ -1,3 +1,4 @@
+// Package git provides git repository operations for Amux.
 package git
 
 import (

--- a/internal/core/index/manager.go
+++ b/internal/core/index/manager.go
@@ -1,3 +1,4 @@
+// Package index provides short index management for entity identification.
 package index
 
 import (

--- a/internal/core/index/types.go
+++ b/internal/core/index/types.go
@@ -21,8 +21,10 @@ func (i Index) IsValid() bool {
 type EntityType string
 
 const (
+	// EntityTypeWorkspace represents a workspace entity
 	EntityTypeWorkspace EntityType = "workspace"
-	EntityTypeSession   EntityType = "session"
+	// EntityTypeSession represents a session entity
+	EntityTypeSession EntityType = "session"
 )
 
 // State represents the internal state of the index manager

--- a/internal/core/session/types.go
+++ b/internal/core/session/types.go
@@ -9,10 +9,14 @@ import (
 type Status string
 
 const (
+	// StatusCreated indicates a session has been created but not started
 	StatusCreated Status = "created"
+	// StatusRunning indicates a session is currently running
 	StatusRunning Status = "running"
+	// StatusStopped indicates a session has been stopped normally
 	StatusStopped Status = "stopped"
-	StatusFailed  Status = "failed"
+	// StatusFailed indicates a session has failed or crashed
+	StatusFailed Status = "failed"
 )
 
 // Options contains options for creating a new session

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -1,3 +1,4 @@
+// Package workspace provides management of isolated git worktree-based development environments.
 package workspace
 
 import (

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -1,3 +1,4 @@
+// Package mcp provides Model Context Protocol server implementation for Amux.
 package mcp
 
 import (
@@ -12,8 +13,8 @@ import (
 
 // StructToToolOptions converts a Go struct to mcp-go tool options using reflection
 
+// StructToToolOptions converts a struct with tags into MCP tool options.
 // The struct should use tags like `json:"name" mcp:"required" description:"Workspace name"`
-
 func StructToToolOptions(structType interface{}) ([]mcp.ToolOption, error) {
 
 	t := reflect.TypeOf(structType)
@@ -173,7 +174,6 @@ func StructToToolOptions(structType interface{}) ([]mcp.ToolOption, error) {
 }
 
 // WithStructOptions is a helper that combines a description with struct-based options
-
 func WithStructOptions(description string, structType interface{}) ([]mcp.ToolOption, error) {
 
 	structOpts, err := StructToToolOptions(structType)
@@ -191,7 +191,6 @@ func WithStructOptions(description string, structType interface{}) ([]mcp.ToolOp
 }
 
 // UnmarshalArgs unmarshals CallToolRequest arguments into a struct
-
 func UnmarshalArgs[T any](request mcp.CallToolRequest, target *T) error {
 
 	args := request.GetArguments()
@@ -216,8 +215,7 @@ func UnmarshalArgs[T any](request mcp.CallToolRequest, target *T) error {
 
 }
 
-// Example usage structures with proper tags
-
+// WorkspaceCreateParams defines parameters for creating a workspace
 type WorkspaceCreateParams struct {
 	Name string `json:"name" mcp:"required" description:"Workspace name"`
 
@@ -230,16 +228,17 @@ type WorkspaceCreateParams struct {
 	Description string `json:"description,omitempty" description:"Description (optional)"`
 }
 
+// WorkspaceListParams defines parameters for listing workspaces
 type WorkspaceListParams struct {
-
 	// No parameters needed for listing workspaces
-
 }
 
+// WorkspaceIDParams defines parameters for workspace operations requiring an ID
 type WorkspaceIDParams struct {
 	WorkspaceID string `json:"workspace_id" mcp:"required" description:"Workspace name or ID"`
 }
 
+// WorkspaceInfoParams defines parameters for getting workspace file information
 type WorkspaceInfoParams struct {
 	WorkspaceID string `json:"workspace_id" mcp:"required" description:"Workspace name or ID"`
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,7 +27,6 @@ import (
 )
 
 // ServerV2 implements the MCP server using mcp-go
-
 type ServerV2 struct {
 	mcpServer *server.MCPServer
 
@@ -41,7 +40,6 @@ type ServerV2 struct {
 }
 
 // NewServerV2 creates a new MCP server using mcp-go
-
 func NewServerV2(configManager *config.Manager, transport string, httpConfig *config.HTTPConfig) (*ServerV2, error) {
 
 	workspaceManager, err := workspace.NewManager(configManager)
@@ -491,7 +489,6 @@ func (s *ServerV2) handleWorkspaceInfo(ctx context.Context, request mcp.CallTool
 }
 
 // Start starts the MCP server
-
 func (s *ServerV2) Start(ctx context.Context) error {
 
 	switch s.transport {

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,3 +1,4 @@
+// Package templates provides workspace template files for AI agent context.
 package templates
 
 import (
@@ -77,7 +78,12 @@ func writeTemplate(path, templateContent string, data TemplateData) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
-	return tmpl.Execute(file, data)
+	err = tmpl.Execute(file, data)
+	return err
 }

--- a/internal/tests/helpers/repo.go
+++ b/internal/tests/helpers/repo.go
@@ -1,3 +1,4 @@
+// Package helpers provides test utilities for Amux tests.
 package helpers
 
 import (
@@ -17,20 +18,20 @@ func CreateTestRepo(t *testing.T) string {
 	origGitIndexFile := os.Getenv("GIT_INDEX_FILE")
 
 	// Clear git environment variables for test isolation
-	os.Unsetenv("GIT_DIR")
-	os.Unsetenv("GIT_WORK_TREE")
-	os.Unsetenv("GIT_INDEX_FILE")
+	_ = os.Unsetenv("GIT_DIR")
+	_ = os.Unsetenv("GIT_WORK_TREE")
+	_ = os.Unsetenv("GIT_INDEX_FILE")
 
 	// Restore original environment after test
 	t.Cleanup(func() {
 		if origGitDir != "" {
-			os.Setenv("GIT_DIR", origGitDir)
+			_ = os.Setenv("GIT_DIR", origGitDir)
 		}
 		if origGitWorkTree != "" {
-			os.Setenv("GIT_WORK_TREE", origGitWorkTree)
+			_ = os.Setenv("GIT_WORK_TREE", origGitWorkTree)
 		}
 		if origGitIndexFile != "" {
-			os.Setenv("GIT_INDEX_FILE", origGitIndexFile)
+			_ = os.Setenv("GIT_INDEX_FILE", origGitIndexFile)
 		}
 	})
 
@@ -51,7 +52,7 @@ func CreateTestRepo(t *testing.T) string {
 		cmd.Dir = tmpDir
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			os.RemoveAll(tmpDir)
+			_ = os.RemoveAll(tmpDir)
 			t.Fatalf("Failed to init git repo: %v, output: %s", err, output)
 		}
 	}
@@ -60,14 +61,14 @@ func CreateTestRepo(t *testing.T) string {
 	cmd = exec.Command("git", "config", "user.email", "test@example.com")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to configure git email: %v", err)
 	}
 
 	cmd = exec.Command("git", "config", "user.name", "Test User")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to configure git name: %v", err)
 	}
 
@@ -79,21 +80,21 @@ func CreateTestRepo(t *testing.T) string {
 	// Create initial commit
 	readmePath := filepath.Join(tmpDir, "README.md")
 	if err := os.WriteFile(readmePath, []byte("# Test Repository\n"), 0644); err != nil {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to create README: %v", err)
 	}
 
 	cmd = exec.Command("git", "add", "README.md")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to add README: %v", err)
 	}
 
 	cmd = exec.Command("git", "commit", "-m", "Initial commit")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to create initial commit: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
Fixes all linting errors detected by golangci-lint v2 after the upgrade in PR #23.

## Changes

### errcheck (12 errors fixed)
- Added proper error handling for `file.Close()` calls using deferred error capture
- Used underscore to explicitly ignore errors in test helpers where appropriate

### revive (28 errors fixed)
- Added package comments to all packages
- Added comments for all exported functions, types, and constants
- Fixed comment formatting to match Go conventions
- Added comments for exported variables and icons

### staticcheck (4 errors fixed)
- Changed error strings to lowercase (following Go conventions)
- Converted if-else chain to switch statement in mock adapter

## Remaining Issues
- One `var-naming` warning for the `common` package remains. This would require refactoring to move `IDMapper` to a more appropriate package, which is beyond the scope of this PR.

## Test plan
- [x] All tests pass
- [x] Linter runs successfully with only one expected warning
- [x] Pre-commit hooks pass

Fixes #24