### PR TITLE
fix(docs): correct ADR dates to match filesystem creation dates

### DIFF
--- a/docs/adr/007-table-library-selection.md
+++ b/docs/adr/007-table-library-selection.md
@@ -1,6 +1,6 @@
 # 7. Table Library Selection
 
-Date: 2025-01-06
+Date: 2025-06-11
 
 ## Status
 

--- a/docs/adr/008-session-mailbox-system.md
+++ b/docs/adr/008-session-mailbox-system.md
@@ -1,6 +1,6 @@
 # 8. Session Mailbox System
 
-Date: 2025-01-11
+Date: 2025-06-11
 
 ## Status
 


### PR DESCRIPTION
## Summary
- Fixed incorrect dates in ADR files that were set to January instead of June

## Changes
- `docs/adr/007-table-library-selection.md`: 2025-01-06 → 2025-06-11
- `docs/adr/008-session-mailbox-system.md`: 2025-01-11 → 2025-06-11

These dates now match the actual file creation dates from the filesystem metadata.