### PR TITLE
feat(build): migrate goimports formatting to golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,14 @@ version: '2'
 run:
   timeout: 5m
   tests: true
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/aki/amux
+        - github.com/choplin/amux
 linters:
   enable:
     - govet

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ test-coverage:
 
 # Format Go code
 fmt:
-    go run -mod=readonly golang.org/x/tools/cmd/goimports -w -local github.com/choplin/amux .
+    go run -mod=readonly github.com/golangci/golangci-lint/v2/cmd/golangci-lint fmt ./...
 
 # Format YAML files
 fmt-yaml:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,8 +13,8 @@ pre-commit:
       glob: "*.{go,md,yml,yaml,txt,json,toml,mod,sum}"
       stage_fixed: true
       priority: 2
-    goimports:
-      run: go run -mod=readonly golang.org/x/tools/cmd/goimports -w -local github.com/aki/amux {staged_files}
+    golangci-fmt:
+      run: go run -mod=readonly github.com/golangci/golangci-lint/v2/cmd/golangci-lint fmt {staged_files}
       glob: "*.go"
       stage_fixed: true
     vet:


### PR DESCRIPTION
## Summary
- Migrated from standalone goimports to golangci-lint v2's built-in formatter
- Consolidated formatting tools under golangci-lint v2 for simplified toolchain

## Changes
1. **Added formatters section to .golangci.yml**
   - Enabled goimports formatter
   - Configured local import prefixes for proper grouping

2. **Updated justfile**
   - Changed `fmt` command from `goimports -w` to `golangci-lint fmt`

3. **Updated lefthook.yml**
   - Renamed pre-commit hook from `goimports` to `golangci-fmt`
   - Uses golangci-lint fmt for Go file formatting

## Benefits
- Single tool for both linting and formatting
- Consistent configuration in `.golangci.yml`
- Simpler dependency management
- Maintains same formatting behavior with local import grouping

## Testing
- Verified `golangci-lint fmt` produces same output as standalone goimports
- Tested import grouping works correctly (stdlib → external → local)
- All tests pass
- Pre-commit hooks work correctly

Fixes #25