### PR TITLE
fix(ui): resolve table formatting issue in workspace list

### DIFF
--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -125,7 +125,6 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 	// Print with header
 	PrintSectionHeader(CaveIcon, "Workspaces", len(workspaces))
 	tbl.Print()
-	fmt.Println()
 }
 
 // PrintWorkspaceDetails displays detailed information about a single workspace

--- a/internal/cli/ui/table.go
+++ b/internal/cli/ui/table.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/rodaine/table"
 )
 
@@ -10,11 +11,10 @@ import (
 func NewTable(headers ...interface{}) table.Table {
 	tbl := table.New(headers...)
 
-	// Apply consistent formatting
-	tbl.WithHeaderFormatter(func(format string, vals ...interface{}) string {
-		return HeaderStyle.Render(fmt.Sprintf(format, vals...))
-	})
+	// Don't use header formatter as it causes layout issues
+	// Instead, we'll style the headers when we create them
 
+	// Only format the first column (ID) with bold
 	tbl.WithFirstColumnFormatter(func(format string, vals ...interface{}) string {
 		return BoldStyle.Render(fmt.Sprintf(format, vals...))
 	})
@@ -22,11 +22,13 @@ func NewTable(headers ...interface{}) table.Table {
 	// Add some padding
 	tbl.WithPadding(2)
 
+	// Use lipgloss Width function to properly calculate string width with ANSI codes
+	tbl.WithWidthFunc(lipgloss.Width)
+
 	return tbl
 }
 
 // PrintSectionHeader prints a consistent section header
 func PrintSectionHeader(icon string, title string, count int) {
-	fmt.Printf("\n%s %s (%d)\n\n", icon, title, count)
-
+	fmt.Printf("\n%s %s (%d)\n", icon, title, count)
 }


### PR DESCRIPTION
## Summary
- Fixed table formatting bug where ID column appeared on a separate line
- Table now displays correctly with all columns properly aligned

## Problem
The `amux ws ls` command had a formatting issue where the ID column was displayed on a separate line from the rest of the row data, making the output difficult to read.

## Root Cause
The issue was caused by the header formatter applying ANSI escape codes (for styling) that confused the table library's layout calculations. The rodaine/table library wasn't properly accounting for these invisible characters when calculating column widths.

## Solution
1. **Removed header formatter** - The header formatter was causing the layout issues
2. **Kept first column formatter** - Still styling the ID column with bold text
3. **Added lipgloss.Width** - Using lipgloss's ANSI-aware width calculation function
4. **Fixed extra newline** - Removed redundant newline in PrintSectionHeader

## Testing
- Tested `amux ws ls` - Table displays correctly
- Tested `amux agent ls` - Table displays correctly
- All unit tests pass

## Before
```
🕳️ Workspaces (2)

ID  NAME                   BRANCH                                                   AGE   DESCRIPTION                                                               
                                                                                                                                                                    
5   test-table-format      amux/workspace-test-table-format-1749658027-2172050c     < 1m  Test workspace to check table formatting                                  
6   feat-mcp-architecture  amux/workspace-feat-mcp-architectur-1749656211-8502edf6  19m   Design comprehensive MCP architecture with resources, prompts, and tools
```

## After
```
🕳️ Workspaces (2)
ID  NAME                   BRANCH                                                   AGE   DESCRIPTION                                                               
5   test-table-format      amux/workspace-test-table-format-1749658027-2172050c     < 1m  Test workspace to check table formatting                                  
6   feat-mcp-architecture  amux/workspace-feat-mcp-architectur-1749656211-8502edf6  19m   Design comprehensive MCP architecture with resources, prompts, and tools
```

Fixes #43