### PR TITLE
fix: handle manual worktree deletion gracefully (#42)

### DIFF
--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -222,7 +222,7 @@ func runListWorkspace(cmd *cobra.Command, args []string) error {
 
 		for _, ws := range workspaces {
 
-			// Format: name<tab>id<tab>branch<tab>path<tab>description
+			// Format: name<tab>id<tab>branch<tab>status<tab>path<tab>description
 
 			description := ws.Description
 
@@ -234,7 +234,7 @@ func runListWorkspace(cmd *cobra.Command, args []string) error {
 			if ws.Index != "" {
 				id = ws.Index
 			}
-			fmt.Printf("%s\t%s\t%s\t%s\t%s\n", ws.Name, id, ws.Branch, ws.Path, description)
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\n", ws.Name, id, ws.Branch, ws.Status, ws.Path, description)
 
 		}
 	} else {

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -234,7 +234,7 @@ func runListWorkspace(cmd *cobra.Command, args []string) error {
 			if ws.Index != "" {
 				id = ws.Index
 			}
-			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\n", ws.Name, id, ws.Branch, ws.Status, ws.Path, description)
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\n", ws.Name, id, ws.Branch, ws.Status.String(), ws.Path, description)
 
 		}
 	} else {

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -71,13 +71,13 @@ func PrintWorkspace(w *workspace.Workspace) {
 	// Show consistency status
 	var statusStr string
 	switch w.Status {
-	case "consistent":
+	case workspace.StatusConsistent:
 		statusStr = SuccessStyle.Render("✓ Consistent")
-	case "folder-missing":
+	case workspace.StatusFolderMissing:
 		statusStr = WarningStyle.Render("⚠ Folder missing (run 'amux ws rm' to clean up)")
-	case "worktree-missing":
+	case workspace.StatusWorktreeMissing:
 		statusStr = WarningStyle.Render("⚠ Git worktree missing (run 'amux ws rm' to clean up)")
-	case "orphaned":
+	case workspace.StatusOrphaned:
 		statusStr = ErrorStyle.Render("✗ Orphaned (both folder and worktree missing)")
 	default:
 		statusStr = DimStyle.Render("Unknown")
@@ -124,13 +124,13 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 		// Format status with appropriate icon
 		var status string
 		switch w.Status {
-		case "consistent":
+		case workspace.StatusConsistent:
 			status = SuccessStyle.Render("✓ ok")
-		case "folder-missing":
+		case workspace.StatusFolderMissing:
 			status = WarningStyle.Render("⚠ folder missing")
-		case "worktree-missing":
+		case workspace.StatusWorktreeMissing:
 			status = WarningStyle.Render("⚠ worktree missing")
-		case "orphaned":
+		case workspace.StatusOrphaned:
 			status = ErrorStyle.Render("✗ orphaned")
 		default:
 			status = DimStyle.Render("unknown")

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -67,6 +67,22 @@ func PrintWorkspace(w *workspace.Workspace) {
 	fmt.Printf("   %s %s\n", DimStyle.Render("Created:"), FormatTime(w.CreatedAt))
 
 	fmt.Printf("   %s %s\n", DimStyle.Render("Updated:"), FormatTime(w.UpdatedAt))
+
+	// Show consistency status
+	var statusStr string
+	switch w.Status {
+	case "consistent":
+		statusStr = SuccessStyle.Render("✓ Consistent")
+	case "folder-missing":
+		statusStr = WarningStyle.Render("⚠ Folder missing (run 'amux ws rm' to clean up)")
+	case "worktree-missing":
+		statusStr = WarningStyle.Render("⚠ Git worktree missing (run 'amux ws rm' to clean up)")
+	case "orphaned":
+		statusStr = ErrorStyle.Render("✗ Orphaned (both folder and worktree missing)")
+	default:
+		statusStr = DimStyle.Render("Unknown")
+	}
+	fmt.Printf("   %s %s\n", DimStyle.Render("Status:"), statusStr)
 }
 
 // FormatDuration formats a duration into a human-readable string
@@ -91,7 +107,7 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 	}
 
 	// Create table
-	tbl := NewTable("ID", "NAME", "BRANCH", "AGE", "DESCRIPTION")
+	tbl := NewTable("ID", "NAME", "BRANCH", "AGE", "STATUS", "DESCRIPTION")
 
 	// Add rows
 	for _, w := range workspaces {
@@ -105,7 +121,22 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 			description = "-"
 		}
 
-		tbl.AddRow(id, w.Name, w.Branch, age, description)
+		// Format status with appropriate icon
+		var status string
+		switch w.Status {
+		case "consistent":
+			status = SuccessStyle.Render("✓ ok")
+		case "folder-missing":
+			status = WarningStyle.Render("⚠ folder missing")
+		case "worktree-missing":
+			status = WarningStyle.Render("⚠ worktree missing")
+		case "orphaned":
+			status = ErrorStyle.Render("✗ orphaned")
+		default:
+			status = DimStyle.Render("unknown")
+		}
+
+		tbl.AddRow(id, w.Name, w.Branch, age, status, description)
 	}
 
 	// Print with header

--- a/internal/core/git/operations.go
+++ b/internal/core/git/operations.go
@@ -115,6 +115,19 @@ func (o *Operations) RemoveWorktree(path string) error {
 	return nil
 }
 
+// PruneWorktrees removes worktree references for directories that no longer exist
+func (o *Operations) PruneWorktrees() error {
+	cmd := exec.Command("git", "worktree", "prune")
+	cmd.Dir = o.repoPath
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to prune worktrees: %s", output)
+	}
+
+	return nil
+}
+
 // CreateBranch creates a new branch from a base branch
 func (o *Operations) CreateBranch(branch, baseBranch string) error {
 	cmd := exec.Command("git", "branch", branch, baseBranch)

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -312,19 +312,19 @@ func (m *Manager) Remove(id string) error {
 
 	// Handle different inconsistency cases
 	switch workspace.Status {
-	case "consistent":
+	case StatusConsistent:
 		// Normal case: both worktree and folder exist
 		if err := m.gitOps.RemoveWorktree(workspace.Path); err != nil {
 			return fmt.Errorf("failed to remove worktree: %w", err)
 		}
-	case "folder-missing":
+	case StatusFolderMissing:
 		// Case 1: Folder deleted but git worktree exists
 		// Need to prune the worktree reference
 		_ = m.gitOps.PruneWorktrees()
-	case "worktree-missing":
+	case StatusWorktreeMissing:
 		// Case 2: Git worktree removed but folder exists
 		// Nothing special needed, will clean up folder below
-	case "orphaned":
+	case StatusOrphaned:
 		// Both are missing, just clean up metadata
 	}
 
@@ -444,13 +444,13 @@ func (m *Manager) CheckConsistency(workspace *Workspace) {
 
 	// Determine status based on existence flags
 	if workspace.PathExists && workspace.WorktreeExists {
-		workspace.Status = "consistent"
+		workspace.Status = StatusConsistent
 	} else if !workspace.PathExists && workspace.WorktreeExists {
-		workspace.Status = "folder-missing"
+		workspace.Status = StatusFolderMissing
 	} else if workspace.PathExists && !workspace.WorktreeExists {
-		workspace.Status = "worktree-missing"
+		workspace.Status = StatusWorktreeMissing
 	} else {
-		workspace.Status = "orphaned"
+		workspace.Status = StatusOrphaned
 	}
 }
 

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -172,6 +172,9 @@ func (m *Manager) Get(id string) (*Workspace, error) {
 		workspace.Index = index
 	}
 
+	// Check consistency status
+	m.CheckConsistency(&workspace)
+
 	return &workspace, nil
 }
 
@@ -214,6 +217,9 @@ func (m *Manager) List(opts ListOptions) ([]*Workspace, error) {
 			index, _ := m.idMapper.AddWorkspace(workspace.ID)
 			workspace.Index = index
 		}
+
+		// Check consistency status
+		m.CheckConsistency(&workspace)
 
 		workspaces = append(workspaces, &workspace)
 	}
@@ -301,24 +307,40 @@ func (m *Manager) Remove(id string) error {
 		return err
 	}
 
-	// Remove git worktree
-	if err := m.gitOps.RemoveWorktree(workspace.Path); err != nil {
-		// Check if worktree is already gone (manually deleted)
-		if strings.Contains(err.Error(), "not a working tree") ||
-			strings.Contains(err.Error(), "No such file or directory") ||
-			strings.Contains(err.Error(), "not a valid path") {
-			// Worktree was already removed, continue with cleanup
-			// Prune git's worktree list to clean up stale references
-			_ = m.gitOps.PruneWorktrees()
-		} else {
+	// Check consistency to determine the right cleanup approach
+	m.CheckConsistency(workspace)
+
+	// Handle different inconsistency cases
+	switch workspace.Status {
+	case "consistent":
+		// Normal case: both worktree and folder exist
+		if err := m.gitOps.RemoveWorktree(workspace.Path); err != nil {
 			return fmt.Errorf("failed to remove worktree: %w", err)
+		}
+	case "folder-missing":
+		// Case 1: Folder deleted but git worktree exists
+		// Need to prune the worktree reference
+		_ = m.gitOps.PruneWorktrees()
+	case "worktree-missing":
+		// Case 2: Git worktree removed but folder exists
+		// Nothing special needed, will clean up folder below
+	case "orphaned":
+		// Both are missing, just clean up metadata
+	}
+
+	// Try to remove git worktree if it exists (for backward compatibility)
+	if workspace.WorktreeExists {
+		if err := m.gitOps.RemoveWorktree(workspace.Path); err != nil {
+			// If it fails, try pruning
+			_ = m.gitOps.PruneWorktrees()
 		}
 	}
 
 	// Delete branch
 	if err := m.gitOps.DeleteBranch(workspace.Branch); err != nil {
-		// If branch doesn't exist, continue
-		if !strings.Contains(err.Error(), "not found") {
+		// If branch doesn't exist or is checked out in a non-existent worktree, continue
+		if !strings.Contains(err.Error(), "not found") &&
+			!strings.Contains(err.Error(), "checked out at") {
 			return fmt.Errorf("failed to delete branch: %w", err)
 		}
 	}
@@ -366,6 +388,70 @@ func (m *Manager) Cleanup(opts CleanupOptions) ([]string, error) {
 	}
 
 	return removed, nil
+}
+
+// CheckConsistency checks the consistency status of a workspace
+func (m *Manager) CheckConsistency(workspace *Workspace) {
+	// Check if workspace folder exists
+	if _, err := os.Stat(workspace.Path); err == nil {
+		workspace.PathExists = true
+	} else {
+		workspace.PathExists = false
+	}
+
+	// Check if git worktree exists
+	worktrees, err := m.gitOps.ListWorktrees()
+	workspace.WorktreeExists = false
+	if err == nil {
+		for _, wt := range worktrees {
+			// Normalize paths for comparison
+			wtPath := filepath.Clean(wt.Path)
+			wsPath := filepath.Clean(workspace.Path)
+
+			// Try to resolve symlinks for both paths to handle macOS /var -> /private/var
+			// We need to resolve even non-existent paths by resolving their parent directories
+			wtPathResolved := wtPath
+			wsPathResolved := wsPath
+
+			// For worktree path
+			if resolvedWt, err := filepath.EvalSymlinks(wtPath); err == nil {
+				wtPathResolved = resolvedWt
+			} else {
+				// If path doesn't exist, try to resolve parent directory
+				wtDir := filepath.Dir(wtPath)
+				if resolvedDir, err := filepath.EvalSymlinks(wtDir); err == nil {
+					wtPathResolved = filepath.Join(resolvedDir, filepath.Base(wtPath))
+				}
+			}
+
+			// For workspace path
+			if resolvedWs, err := filepath.EvalSymlinks(wsPath); err == nil {
+				wsPathResolved = resolvedWs
+			} else {
+				// If path doesn't exist, try to resolve parent directory
+				wsDir := filepath.Dir(wsPath)
+				if resolvedDir, err := filepath.EvalSymlinks(wsDir); err == nil {
+					wsPathResolved = filepath.Join(resolvedDir, filepath.Base(wsPath))
+				}
+			}
+
+			if wtPathResolved == wsPathResolved {
+				workspace.WorktreeExists = true
+				break
+			}
+		}
+	}
+
+	// Determine status based on existence flags
+	if workspace.PathExists && workspace.WorktreeExists {
+		workspace.Status = "consistent"
+	} else if !workspace.PathExists && workspace.WorktreeExists {
+		workspace.Status = "folder-missing"
+	} else if workspace.PathExists && !workspace.WorktreeExists {
+		workspace.Status = "worktree-missing"
+	} else {
+		workspace.Status = "orphaned"
+	}
 }
 
 // saveWorkspace saves workspace metadata to disk

--- a/internal/core/workspace/manager_test.go
+++ b/internal/core/workspace/manager_test.go
@@ -235,8 +235,8 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 		t.Logf("Path exists: %v, Worktree exists: %v, Status: %s",
 			retrieved.PathExists, retrieved.WorktreeExists, retrieved.Status)
 
-		if retrieved.Status != "consistent" {
-			t.Errorf("Expected status 'consistent', got '%s'", retrieved.Status)
+		if retrieved.Status != workspace.StatusConsistent {
+			t.Errorf("Expected status StatusConsistent, got '%s'", retrieved.Status)
 		}
 		if !retrieved.PathExists {
 			t.Error("Expected PathExists to be true")
@@ -284,8 +284,8 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 		t.Logf("Path exists: %v, Worktree exists: %v, Status: %s",
 			retrieved.PathExists, retrieved.WorktreeExists, retrieved.Status)
 
-		if retrieved.Status != "folder-missing" {
-			t.Errorf("Expected status 'folder-missing', got '%s'", retrieved.Status)
+		if retrieved.Status != workspace.StatusFolderMissing {
+			t.Errorf("Expected status StatusFolderMissing, got '%s'", retrieved.Status)
 		}
 		if retrieved.PathExists {
 			t.Error("Expected PathExists to be false")
@@ -365,8 +365,8 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 		t.Logf("Path exists: %v, Worktree exists: %v, Status: %s",
 			retrieved.PathExists, retrieved.WorktreeExists, retrieved.Status)
 
-		if retrieved.Status != "worktree-missing" {
-			t.Errorf("Expected status 'worktree-missing', got '%s'", retrieved.Status)
+		if retrieved.Status != workspace.StatusWorktreeMissing {
+			t.Errorf("Expected status StatusWorktreeMissing, got '%s'", retrieved.Status)
 		}
 		if !retrieved.PathExists {
 			t.Error("Expected PathExists to be true")

--- a/internal/core/workspace/types.go
+++ b/internal/core/workspace/types.go
@@ -2,6 +2,64 @@ package workspace
 
 import "time"
 
+// ConsistencyStatus represents the consistency state of a workspace
+type ConsistencyStatus int
+
+const (
+	// StatusConsistent indicates both folder and git worktree exist
+	StatusConsistent ConsistencyStatus = iota
+	// StatusFolderMissing indicates git worktree exists but folder is missing
+	StatusFolderMissing
+	// StatusWorktreeMissing indicates folder exists but git worktree is missing
+	StatusWorktreeMissing
+	// StatusOrphaned indicates both folder and git worktree are missing
+	StatusOrphaned
+)
+
+// String returns the string representation of ConsistencyStatus
+func (s ConsistencyStatus) String() string {
+	switch s {
+	case StatusConsistent:
+		return "consistent"
+	case StatusFolderMissing:
+		return "folder-missing"
+	case StatusWorktreeMissing:
+		return "worktree-missing"
+	case StatusOrphaned:
+		return "orphaned"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON implements json.Marshaler for ConsistencyStatus
+func (s ConsistencyStatus) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for ConsistencyStatus
+func (s *ConsistencyStatus) UnmarshalJSON(data []byte) error {
+	str := string(data)
+	// Remove quotes
+	if len(str) >= 2 && str[0] == '"' && str[len(str)-1] == '"' {
+		str = str[1 : len(str)-1]
+	}
+
+	switch str {
+	case "consistent":
+		*s = StatusConsistent
+	case "folder-missing":
+		*s = StatusFolderMissing
+	case "worktree-missing":
+		*s = StatusWorktreeMissing
+	case "orphaned":
+		*s = StatusOrphaned
+	default:
+		*s = StatusConsistent // Default to consistent if unknown
+	}
+	return nil
+}
+
 // Workspace represents an isolated development environment
 type Workspace struct {
 	ID          string    `yaml:"id" json:"id"`
@@ -16,9 +74,9 @@ type Workspace struct {
 	UpdatedAt   time.Time `yaml:"-" json:"updatedAt"` // Dynamically populated from filesystem
 
 	// Consistency status fields (not persisted)
-	PathExists     bool   `yaml:"-" json:"pathExists"`
-	WorktreeExists bool   `yaml:"-" json:"worktreeExists"`
-	Status         string `yaml:"-" json:"status"` // "consistent", "folder-missing", "worktree-missing", "orphaned"
+	PathExists     bool              `yaml:"-" json:"pathExists"`
+	WorktreeExists bool              `yaml:"-" json:"worktreeExists"`
+	Status         ConsistencyStatus `yaml:"-" json:"status"`
 }
 
 // CreateOptions represents options for creating a new workspace

--- a/internal/core/workspace/types.go
+++ b/internal/core/workspace/types.go
@@ -14,6 +14,11 @@ type Workspace struct {
 	Description string    `yaml:"description,omitempty" json:"description,omitempty"`
 	CreatedAt   time.Time `yaml:"createdAt" json:"createdAt"`
 	UpdatedAt   time.Time `yaml:"-" json:"updatedAt"` // Dynamically populated from filesystem
+
+	// Consistency status fields (not persisted)
+	PathExists     bool   `yaml:"-" json:"pathExists"`
+	WorktreeExists bool   `yaml:"-" json:"worktreeExists"`
+	Status         string `yaml:"-" json:"status"` // "consistent", "folder-missing", "worktree-missing", "orphaned"
 }
 
 // CreateOptions represents options for creating a new workspace


### PR DESCRIPTION
## Summary
- Fixes workspace removal when worktree has been manually deleted
- Adds workspace consistency status tracking and display
- Handles two distinct cases of inconsistency with appropriate cleanup
- Includes comprehensive test coverage for all scenarios

## Problem
When a user manually deletes a git worktree (e.g., `rm -rf .amux/workspaces/workspace-xxx`), the workspace metadata remains but `amux ws rm` fails because it tries to remove the non-existent worktree.

Additionally, users had no visibility into workspace health status when inconsistencies occurred.

## Solution

### 1. Enhanced Workspace Removal
- Modified the `Remove` method to detect and handle different inconsistency cases
- Added automatic `git worktree prune` when worktree is missing
- Improved error handling for "worktree missing" scenarios

### 2. Consistency Status Tracking
Added status tracking to detect and display four states:
- **"consistent"**: Both folder and git worktree exist
- **"folder-missing"**: Git worktree exists but folder was manually deleted  
- **"worktree-missing"**: Folder exists but git worktree was removed
- **"orphaned"**: Both folder and git worktree are missing

### 3. UI Improvements
- `amux ws list` now shows consistency status with visual indicators
- `amux ws get` displays detailed status with cleanup instructions
- Oneline format includes status for scripting integration

### 4. Implementation Details
- Added `CheckConsistency()` method with path normalization for macOS symlinks
- Handle both cases: manual folder deletion vs `git worktree remove`
- Added `PruneWorktrees()` method to clean up git's internal references

## Test plan
- [x] Added `TestManager_RemoveWithManuallyDeletedWorktree` test case
- [x] Added `TestManager_ConsistencyChecking` with three sub-tests:
  - ConsistentWorkspace
  - FolderMissing  
  - WorktreeMissing
- [x] All existing workspace tests pass
- [x] Manual testing of various inconsistency scenarios

## Example Output

```
$ amux ws list
🏔️  Workspaces (3)

ID   NAME              BRANCH                         AGE   STATUS              DESCRIPTION
1    fix-auth          amux/workspace-fix-auth-...    2h    ✓ ok               Fix authentication
2    deleted-folder    amux/workspace-deleted-...     1h    ⚠ folder missing    Test workspace
3    no-worktree       amux/workspace-no-wt-...       30m   ⚠ worktree missing  Manual removal test

$ amux ws get 2
🏔️  Workspace Details

📁 deleted-folder (2) updated 1h ago
   Branch: amux/workspace-deleted-folder-xyz
   Path: /path/to/.amux/workspaces/workspace-deleted-folder-xyz
   Created: 2025-01-10 15:30:00
   Updated: 2025-01-10 16:30:00
   Status: ⚠ Folder missing (run 'amux ws rm' to clean up)
```

Fixes #42