### PR TITLE
docs: update workspace cleanup workflow to include main branch sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,16 @@ When working on GitHub issues with AI agents (like Claude), follow this workflow
 
 5. **After PR is merged**, AI cleans up:
 
-   ```typescript
+   ```bash
+   # First, change to main repository directory
+   cd /Users/aki/workspace/amux
+
+   # Remove the workspace
    workspace_remove({ workspace_id: "fix-issue-30" });
+
+   # Update main branch
+   git checkout main
+   git pull origin main
    ```
 
 ### Available MCP Tools for AI Agents


### PR DESCRIPTION
## Summary

This PR updates the workspace cleanup workflow documentation to include steps for syncing the main branch after completing work on an issue.

## Changes

- Added steps to the "After PR is merged" section:
  - Change to main repository directory
  - Switch to main branch after removing workspace
  - Pull latest changes from origin

## Rationale

Ensures the main branch is always up to date after completing work, preventing situations where the local main branch falls behind origin/main.