### PR TITLE
refactor: rename 'ws get' to 'ws show' for better CLI semantics (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ amux init
 # Workspace management
 amux ws create <name> [--description "..."] [--branch existing-branch]
 amux ws list
-amux ws get <id-or-name>
+amux ws show <id-or-name>
 amux ws remove <id-or-name>
 
 # Start MCP server

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ amux attach session-abc123
 # Workspace management
 amux workspace create <name>    # alias: amux ws create
 amux workspace list            # alias: amux ws list
-amux workspace get <id>        # alias: amux ws get
+amux workspace show <id>       # alias: amux ws show
 amux workspace remove <id>     # alias: amux ws remove
 amux workspace prune           # alias: amux ws prune
 
@@ -108,8 +108,8 @@ amux ws create feature-auth --description "Implement authentication"
 # Create a workspace using an existing branch
 amux ws create bugfix-ui --branch fix/ui-crash --description "Fix UI crash"
 
-# Get details about a specific workspace
-amux ws get workspace-abc123
+# Show details about a specific workspace
+amux ws show workspace-abc123
 
 # List all workspaces
 amux ws list

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -56,7 +56,7 @@ func init() {
 
 	workspaceCmd.AddCommand(listWorkspaceCmd)
 
-	workspaceCmd.AddCommand(getWorkspaceCmd)
+	workspaceCmd.AddCommand(showWorkspaceCmd)
 
 	workspaceCmd.AddCommand(removeWorkspaceCmd)
 
@@ -135,11 +135,11 @@ Examples:
 	RunE: runListWorkspace,
 }
 
-var getWorkspaceCmd = &cobra.Command{
-	Use:   "get <workspace-name-or-id>",
-	Short: "Get detailed information about a workspace",
+var showWorkspaceCmd = &cobra.Command{
+	Use:   "show <workspace-name-or-id>",
+	Short: "Show detailed information about a workspace",
 	Args:  cobra.ExactArgs(1),
-	RunE:  runGetWorkspace,
+	RunE:  runShowWorkspace,
 }
 
 var removeWorkspaceCmd = &cobra.Command{
@@ -244,7 +244,7 @@ func runListWorkspace(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runGetWorkspace(cmd *cobra.Command, args []string) error {
+func runShowWorkspace(cmd *cobra.Command, args []string) error {
 	identifier := args[0]
 
 	manager, err := getWorkspaceManager()


### PR DESCRIPTION
## Summary
- Renamed `ws get` command to `ws show` to align with CLI conventions
- Updated all code references, help text, and documentation
- No backward compatibility maintained as requested

## Why this change?
The `show` verb better represents displaying detailed information about a resource, following patterns from other CLIs:
- `git show` - displays information about commits, tags, etc.
- `docker container show` - shows detailed container information  
- `gh pr show` - displays PR details

## Test plan
- [x] All existing tests pass
- [x] Manual testing of `amux ws show <id>` command works correctly
- [x] Help text updated appropriately
- [x] Documentation updated (except ADRs which remain immutable)

Fixes #60