### PR TITLE
refactor: rename common package to idmap for better clarity (#55)

### DIFF
--- a/internal/cli/commands/agent.go
+++ b/internal/cli/commands/agent.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/aki/amux/internal/cli/ui"
 	"github.com/aki/amux/internal/core/agent"
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -176,7 +176,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}
@@ -244,7 +244,7 @@ func listAgents(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}
@@ -336,7 +336,7 @@ func attachAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}
@@ -391,7 +391,7 @@ func stopAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}
@@ -434,7 +434,7 @@ func viewAgentLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}

--- a/internal/cli/commands/helpers.go
+++ b/internal/cli/commands/helpers.go
@@ -3,15 +3,15 @@ package commands
 import (
 	"fmt"
 
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
 )
 
 // createSessionManager is a helper to create a session manager with all dependencies
-func createSessionManager(configManager *config.Manager, wsManager *workspace.Manager, idMapper *common.IDMapper) (*session.Manager, error) {
+func createSessionManager(configManager *config.Manager, wsManager *workspace.Manager, idMapper *idmap.IDMapper) (*session.Manager, error) {
 	store, err := session.NewFileStore(configManager.GetAmuxDir())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session store: %w", err)

--- a/internal/cli/commands/mailbox_list.go
+++ b/internal/cli/commands/mailbox_list.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aki/amux/internal/cli/ui"
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -62,7 +62,7 @@ func listMailbox(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}

--- a/internal/cli/commands/mailbox_recv.go
+++ b/internal/cli/commands/mailbox_recv.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aki/amux/internal/cli/ui"
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -57,7 +57,7 @@ func recvFromSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}

--- a/internal/cli/commands/mailbox_send.go
+++ b/internal/cli/commands/mailbox_send.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aki/amux/internal/cli/ui"
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -107,7 +107,7 @@ func sendToSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper (workspace manager already has it internally)
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}

--- a/internal/cli/commands/mailbox_show.go
+++ b/internal/cli/commands/mailbox_show.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aki/amux/internal/cli/ui"
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -76,7 +76,7 @@ func showMessages(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get ID mapper
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return fmt.Errorf("failed to create ID mapper: %w", err)
 	}

--- a/internal/core/idmap/idmap.go
+++ b/internal/core/idmap/idmap.go
@@ -1,7 +1,5 @@
-// Package common provides shared utilities for Amux core functionality.
-//
-//nolint:revive
-package common
+// Package idmap provides ID mapping functionality for Amux entities.
+package idmap
 
 import (
 	"fmt"

--- a/internal/core/session/manager.go
+++ b/internal/core/session/manager.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/aki/amux/internal/adapters/tmux"
-	"github.com/aki/amux/internal/core/common"
 	contextmgr "github.com/aki/amux/internal/core/context"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/mailbox"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -132,12 +132,12 @@ type Manager struct {
 	mailboxManager   *mailbox.Manager
 	tmuxAdapter      tmux.Adapter
 	sessions         map[string]Session
-	idMapper         *common.IDMapper
+	idMapper         *idmap.IDMapper
 	mu               sync.RWMutex
 }
 
 // NewManager creates a new session manager
-func NewManager(store Store, workspaceManager *workspace.Manager, mailboxManager *mailbox.Manager, idMapper *common.IDMapper) *Manager {
+func NewManager(store Store, workspaceManager *workspace.Manager, mailboxManager *mailbox.Manager, idMapper *idmap.IDMapper) *Manager {
 	// Try to create tmux adapter, but don't fail if unavailable
 	tmuxAdapter, _ := tmux.NewAdapter()
 

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
-	"github.com/aki/amux/internal/core/common"
 	"github.com/aki/amux/internal/core/config"
 	"github.com/aki/amux/internal/core/git"
+	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/templates"
 )
 
@@ -23,7 +23,7 @@ type Manager struct {
 	configManager *config.Manager
 	gitOps        *git.Operations
 	workspacesDir string
-	idMapper      *common.IDMapper
+	idMapper      *idmap.IDMapper
 }
 
 // NewManager creates a new workspace manager
@@ -37,7 +37,7 @@ func NewManager(configManager *config.Manager) (*Manager, error) {
 	workspacesDir := configManager.GetWorkspacesDir()
 
 	// Initialize ID mapper
-	idMapper, err := common.NewIDMapper(configManager.GetAmuxDir())
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize ID mapper: %w", err)
 	}


### PR DESCRIPTION
## Summary

This PR renames the `internal/core/common` package to `internal/core/idmap` to address the linter warning about meaningless package names and provide a more descriptive name that reflects the actual purpose of the package.

## Changes

- ✅ Renamed directory `internal/core/common/` to `internal/core/idmap/`
- ✅ Updated package declaration from `package common` to `package idmap`
- ✅ Updated all imports across 8 files in the codebase
- ✅ Removed the `//nolint:revive` directive as it's no longer needed

## Benefits

- More descriptive package name that clearly indicates its purpose (ID mapping functionality)
- Satisfies the linter without suppression directives
- Follows Go best practices for package naming
- Prevents future confusion about what belongs in this package

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] No linting errors from the renamed package

Fixes #55