### PR TITLE
refactor: rename CaveIcon to WorkspaceIcon and update icon choices (#27)

### DIFF
--- a/internal/cli/ui/colors.go
+++ b/internal/cli/ui/colors.go
@@ -25,8 +25,8 @@ var (
 	// HeaderStyle is the style for headers
 	HeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFFFFF"))
 
-	// CaveIcon is the icon for caves/workspaces
-	CaveIcon = "🕳️"
+	// WorkspaceIcon is the icon for workspaces
+	WorkspaceIcon = "📋"
 
 	// SuccessIcon is the icon for success messages
 	SuccessIcon = "✅"
@@ -35,7 +35,7 @@ var (
 	ErrorIcon = "❌"
 
 	// InfoIcon is the icon for informational messages
-	InfoIcon = "ℹ️"
+	InfoIcon = "ⓘ"
 
 	// WarningIcon is the icon for warning messages
 	WarningIcon = "⚠️"

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -180,13 +180,13 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 	}
 
 	// Print with header
-	PrintSectionHeader(CaveIcon, "Workspaces", len(workspaces))
+	PrintSectionHeader(WorkspaceIcon, "Workspaces", len(workspaces))
 	tbl.Print()
 }
 
 // PrintWorkspaceDetails displays detailed information about a single workspace
 func PrintWorkspaceDetails(w *workspace.Workspace) {
-	OutputLine("%s Workspace Details\n", CaveIcon)
+	OutputLine("%s Workspace Details\n", WorkspaceIcon)
 	PrintWorkspace(w)
 }
 


### PR DESCRIPTION
## Summary

- Renamed `CaveIcon` to `WorkspaceIcon` for better clarity
- Changed workspace section icon from 🕳️ (hole) to 📋 (clipboard)
- Updated `InfoIcon` from ℹ️ to ⓘ (circled letter) for better font compatibility

## Motivation

The original hole emoji (🕳️) for representing workspaces was unclear. The clipboard icon (📋) better represents:
- A collection/list of workspaces
- Task organization and management
- Active work environment

The Info icon was updated to improve display compatibility across different fonts and terminals, particularly for UDev Gothic font on macOS/wezterm where variation selectors can cause icons to display very small.

## Test Plan

- [x] All tests pass
- [x] Linting and formatting checks pass
- [x] Visual verification that icons display correctly

Closes #27