### PR TITLE
docs: establish documentation structure and extract design decisions (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,11 @@ go test ./internal/core/config
 
 ## 📚 Documentation
 
+- [Documentation Guide](docs/README.md) - Overview of our documentation structure
 - [MCP Integration](docs/mcp.md) - Model Context Protocol resources, tools, and prompts
 - [Agent Multiplexing Guide](docs/agent-multiplexing.md) - Complete guide to running multiple agents
 - [Architecture](docs/architecture.md) - System design and technical details
+- [Architecture Decision Records](docs/adr/) - Design decisions and rationale
 - [Development Guide](DEVELOPMENT.md) - Setup and contribution guidelines
 - [Project Memory](CLAUDE.md) - AI agent context and project knowledge
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,152 @@
+# Amux Documentation Guide
+
+This guide explains our documentation structure and helps you decide where to add new documentation.
+
+## Documentation Types
+
+### 🎯 Architecture Decision Records (ADRs)
+
+**Location**: `docs/adr/`
+**Purpose**: Document design decisions and rationale
+**When to use**: When making architectural or design decisions
+
+ADRs answer "**why**" questions:
+
+- Why did we choose X over Y?
+- What alternatives did we consider?
+- What are the trade-offs?
+- What are the consequences?
+
+**Example**: [ADR-001: Use Git Worktrees for Workspace Isolation](adr/001-git-worktrees-for-workspace-isolation.md)
+
+### 📐 Architecture Documentation
+
+**Location**: `docs/architecture.md`
+**Purpose**: Describe the current system structure
+**When to use**: Documenting how the system is organized
+
+Architecture docs answer "**what**" questions:
+
+- What are the main components?
+- What are their responsibilities?
+- How do they interact?
+- What is the directory structure?
+
+**Note**: Reference ADRs for the "why" behind architectural choices.
+
+### 🔧 Component Documentation
+
+**Location**: `docs/{component}.md`
+**Purpose**: Detailed technical documentation
+**When to use**: Documenting specific subsystems or features
+
+Component docs provide:
+
+- Detailed API documentation
+- Configuration options
+- Usage examples
+- Implementation details
+- Troubleshooting guides
+
+**Examples**:
+
+- [MCP Integration](mcp.md)
+- Future: Session Management, Agent System
+
+### 📚 User Documentation
+
+**Location**: `README.md`, Wiki, or separate docs
+**Purpose**: Help users understand and use Amux
+**When to use**: Documenting features, workflows, or tutorials
+
+## Where Should I Document?
+
+Use this decision tree:
+
+```mermaid
+graph TD
+    A[New Documentation] --> B{Is it a design decision?}
+    B -->|Yes| C[Create/Update ADR]
+    B -->|No| D{Is it about system structure?}
+    D -->|Yes| E[Update architecture.md]
+    D -->|No| F{Is it component-specific?}
+    F -->|Yes| G[Create/Update component doc]
+    F -->|No| H[Update README or user docs]
+```
+
+## Examples
+
+### Example 1: Choosing a New Library
+
+**Scenario**: You're deciding whether to use library X or Y
+**Document in**: New ADR
+**Why**: This is a design decision with trade-offs
+
+### Example 2: Adding a New Component
+
+**Scenario**: You've added a new subsystem
+**Document in**:
+
+1. Update `architecture.md` to show where it fits
+2. Create `docs/{component}.md` for details
+3. Create ADR if there were significant design decisions
+
+### Example 3: Changing an Implementation
+
+**Scenario**: You're refactoring how sessions are stored
+**Document in**:
+
+1. Create ADR for the decision to change
+2. Update component documentation with new details
+3. Update architecture.md if structural changes
+
+## Best Practices
+
+### For ADRs
+
+- Keep them immutable once accepted
+- Number them sequentially
+- Include context, decision, and consequences
+- Reference related ADRs
+- Be honest about trade-offs
+
+### For Architecture Docs
+
+- Keep descriptions current
+- Focus on "what" not "why"
+- Use diagrams where helpful
+- Reference ADRs for rationale
+- Update when structure changes
+
+### For Component Docs
+
+- Include practical examples
+- Document both public and internal APIs
+- Keep troubleshooting sections updated
+- Include performance considerations
+- Document configuration options
+
+## Contributing
+
+When contributing documentation:
+
+1. **Check existing docs** - Avoid duplication
+2. **Follow the structure** - Use the decision tree above
+3. **Cross-reference** - Link between related documents
+4. **Keep it current** - Update docs with code changes
+5. **Be concise** - Clear and focused documentation
+
+## Quick Reference
+
+| Question | Document Type | Location |
+|----------|--------------|----------|
+| Why did we choose X? | ADR | `docs/adr/` |
+| How does X work? | Architecture/Component | `docs/architecture.md` or `docs/{component}.md` |
+| How do I use X? | User docs | `README.md` or component docs |
+| What are the trade-offs of X? | ADR | `docs/adr/` |
+| What is the structure of X? | Architecture | `docs/architecture.md` |
+| What are the details of X? | Component | `docs/{component}.md` |
+
+## References
+
+- [ADR-010: Documentation Structure Strategy](adr/010-documentation-structure.md) - The decision behind this structure

--- a/docs/adr/010-documentation-structure.md
+++ b/docs/adr/010-documentation-structure.md
@@ -1,0 +1,121 @@
+# ADR-010: Documentation Structure Strategy
+
+Date: 2025-06-12
+
+## Status
+
+Accepted
+
+## Context
+
+Our documentation has evolved organically, leading to unclear boundaries between different types of
+documentation. We currently have:
+
+- Design decisions mixed with descriptive documentation in `architecture.md`
+- Rationale and trade-offs documented outside of ADRs
+- Unclear guidance on where to document new information
+- Redundant information across multiple documents
+
+This creates maintenance challenges:
+
+- Contributors are unsure where to add documentation
+- Information becomes outdated in multiple places
+- The "why" (decisions) and "what" (current state) are intermingled
+- ADRs lose their value as immutable decision records
+
+## Decision
+
+We will establish a clear documentation structure with distinct purposes for each type:
+
+### 1. Architecture Decision Records (ADRs)
+
+**Purpose**: Document the "why" - design decisions, rationale, and trade-offs
+**Characteristics**: Immutable once accepted
+**Location**: `docs/adr/`
+**Content**:
+
+- Context and problem statement
+- Considered alternatives
+- Decision rationale
+- Trade-offs and consequences
+- Implementation notes if relevant
+
+### 2. Architecture Documentation
+
+**Purpose**: Document the "what" - current system state and structure
+**Characteristics**: Living document that evolves with the system
+**Location**: `docs/architecture.md`
+**Content**:
+
+- Component overview and responsibilities
+- Data flow diagrams
+- System architecture diagrams
+- Directory structure
+- API/Interface documentation
+- Extension points
+- References to ADRs for rationale
+
+### 3. Component Documentation
+
+**Purpose**: Detailed documentation for specific subsystems
+**Characteristics**: Technical reference for developers
+**Location**: `docs/{component}.md` (e.g., `docs/mcp.md`)
+**Content**:
+
+- Detailed API documentation
+- Usage examples
+- Configuration options
+- Implementation details
+- Troubleshooting guides
+
+### 4. Documentation Guide
+
+**Purpose**: Help contributors understand our documentation strategy
+**Location**: `docs/README.md`
+**Content**:
+
+- Overview of documentation types
+- Decision tree for where to document
+- Examples of each type
+- Contribution guidelines
+
+## Consequences
+
+### Positive
+
+- Clear separation of concerns between decision records and current state
+- ADRs remain focused on decisions and rationale
+- Architecture documentation can evolve without affecting decision history
+- Contributors have clear guidance on where to document
+- Reduced redundancy and maintenance burden
+- Better discoverability of information
+
+### Negative
+
+- Initial effort required to refactor existing documentation
+- Need to educate contributors on the structure
+- More documents to maintain (though with clearer boundaries)
+
+### Neutral
+
+- Cross-references needed between documents
+- Some duplication acceptable (e.g., brief context in architecture.md with ADR reference)
+
+## Implementation
+
+1. Create `docs/README.md` explaining the documentation structure
+2. Extract design decisions from `architecture.md` into new ADRs:
+   - ADR-011: Git Worktrees for Workspace Isolation
+   - ADR-012: Tmux for Session Management
+   - ADR-013: YAML for Configuration
+   - ADR-014: File-based Session Store
+3. Refactor `architecture.md` to remove rationale/trade-offs
+4. Update cross-references between documents
+5. Add documentation structure to contributing guidelines
+
+## References
+
+- [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+  by Michael Nygard
+- [Arc42 Documentation Structure](https://arc42.org/)
+- [C4 Model](https://c4model.com/) for architecture diagrams

--- a/docs/adr/011-git-worktrees-for-workspace-isolation.md
+++ b/docs/adr/011-git-worktrees-for-workspace-isolation.md
@@ -1,0 +1,95 @@
+# ADR-011: Git Worktrees for Workspace Isolation
+
+Date: 2025-06-12
+
+## Status
+
+Accepted
+
+## Context
+
+Amux needs to provide isolated development environments where multiple AI agents can work simultaneously without
+interfering with each other. We need a solution that:
+
+- Provides true filesystem isolation between agents
+- Allows parallel development on different features
+- Integrates with existing git workflows
+- Enables easy merging of changes back to main
+- Is familiar to developers
+
+Several options were considered:
+
+1. **Shared working directory with branches** - Agents work in the same directory but on different branches
+2. **Docker containers** - Each agent gets a containerized environment
+3. **Virtual machines** - Full VM isolation per agent
+4. **Git worktrees** - Separate working directories linked to the same repository
+5. **Copy repositories** - Full clones for each workspace
+
+## Decision
+
+We will use Git worktrees to provide isolated workspaces for AI agents.
+
+Each workspace will:
+
+- Be created as a new git worktree
+- Have its own dedicated branch
+- Exist in a separate directory under `.amux/workspaces/`
+- Maintain full filesystem isolation from other workspaces
+
+## Consequences
+
+### Positive
+
+- **True filesystem isolation** - Agents can modify files without affecting others
+- **Parallel development** - Multiple agents can work simultaneously
+- **Standard git workflows** - Merging is done through normal git operations
+- **Lightweight branching** - Worktrees share the same git object database
+- **Developer familiarity** - Git worktrees are a standard git feature
+- **Easy cleanup** - Removing a worktree is a simple operation
+
+### Negative
+
+- **Disk space usage** - Each workspace needs a full copy of the working tree
+- **Worktree complexity** - Requires understanding of git worktree mechanics
+- **Git version dependency** - Requires git 2.5+ for worktree support
+- **Potential for orphaned worktrees** - Need cleanup mechanisms
+
+### Neutral
+
+- Worktrees are linked to the main repository
+- Changes still need to be committed and pushed
+- Branch management becomes more important
+
+## Implementation Notes
+
+1. Workspaces are created in `.amux/workspaces/workspace-{name}-{timestamp}-{hash}/`
+2. Each workspace gets a branch named `amux/workspace-{name}-{timestamp}-{hash}`
+3. Workspace metadata is stored both in the main repo and within each workspace
+4. Cleanup involves removing both the worktree and the branch
+
+## Alternatives Considered
+
+### Shared Directory with Branches
+
+**Pros**: Simple, no extra disk space
+**Cons**: No isolation, agents interfere with each other, can't work on same files
+
+### Docker Containers
+
+**Pros**: Strong isolation, reproducible environments
+**Cons**: Complexity, requires Docker, harder git integration, resource overhead
+
+### Virtual Machines
+
+**Pros**: Complete isolation
+**Cons**: Heavy resource usage, complex setup, slow creation
+
+### Full Repository Clones
+
+**Pros**: Complete isolation, simple concept
+**Cons**: Disk space for git objects, slower creation, complex remote management
+
+## References
+
+- [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
+- [ADR-001: Initial Architecture Decisions](001-initial-architecture.md)

--- a/docs/adr/012-tmux-for-session-management.md
+++ b/docs/adr/012-tmux-for-session-management.md
@@ -1,0 +1,105 @@
+# ADR-012: Tmux for Session Management
+
+Date: 2025-06-12
+
+## Status
+
+Accepted
+
+## Context
+
+Amux needs to manage long-running terminal sessions for AI agents. These sessions must:
+
+- Persist beyond the initial command execution
+- Allow attachment and detachment
+- Support sending commands programmatically
+- Capture output for monitoring
+- Work across SSH connections
+- Be discoverable and manageable
+
+Options considered:
+
+1. **GNU Screen** - Alternative terminal multiplexer
+2. **Custom PTY management** - Direct pseudo-terminal handling
+3. **Docker containers** - Container-based sessions
+4. **Tmux** - Terminal multiplexer
+5. **Simple background processes** - Basic process management
+
+## Decision
+
+We will use Tmux as the primary backend for session management, with a fallback to basic sessions when Tmux is unavailable.
+
+The implementation will:
+
+- Use tmux for persistent terminal sessions
+- Provide a clean adapter interface for future backends
+- Support basic sessions as a fallback
+- Manage tmux sessions with amux-specific naming
+
+## Consequences
+
+### Positive
+
+- **Persistent sessions** - Sessions survive network disconnections
+- **Attach/detach capability** - Users can connect to running sessions
+- **Standard tool** - Tmux is widely available and well-documented
+- **Rich feature set** - Window management, scripting, output capture
+- **SSH-friendly** - Works well over remote connections
+- **Programmatic control** - Full API for session manipulation
+
+### Negative
+
+- **External dependency** - Requires tmux installation
+- **Platform variations** - Behavior differences across OS versions
+- **Learning curve** - Users need basic tmux knowledge
+- **Resource overhead** - Each session has tmux process overhead
+
+### Neutral
+
+- Tmux configuration affects behavior
+- Users can use native tmux commands alongside amux
+- Session naming must avoid conflicts
+
+## Implementation Notes
+
+1. Sessions are named `amux-{workspace}-{id}` for easy identification
+2. The `TmuxAdapter` implements the `Adapter` interface
+3. Environment variables are set at session creation time
+4. Fallback to `BasicSession` when tmux is unavailable
+5. Session metadata is stored separately from tmux state
+
+## Alternatives Considered
+
+### GNU Screen
+
+**Pros**: Similar features to tmux, mature tool
+**Cons**: Less active development, fewer features, less programmatic control
+
+### Custom PTY Management
+
+**Pros**: No external dependencies, full control
+**Cons**: Complex implementation, platform-specific code, reinventing the wheel
+
+### Docker Containers
+
+**Pros**: Strong isolation, reproducible
+**Cons**: Heavy dependencies, complex networking, requires Docker daemon
+
+### Simple Background Processes
+
+**Pros**: Simple implementation, no dependencies
+**Cons**: No persistence, no attach capability, limited control
+
+## Future Considerations
+
+The adapter pattern allows for future backends:
+
+- Docker/Kubernetes for cloud environments
+- Custom PTY for embedded systems
+- Remote session protocols for distributed setups
+
+## References
+
+- [Tmux Manual](https://man7.org/linux/man-pages/man1/tmux.1.html)
+- [Terminal Multiplexers Comparison](https://en.wikipedia.org/wiki/Terminal_multiplexer)
+- Session Adapter Interface in `internal/adapters/tmux/adapter.go`

--- a/docs/adr/013-yaml-for-configuration.md
+++ b/docs/adr/013-yaml-for-configuration.md
@@ -1,0 +1,133 @@
+# ADR-013: YAML for Configuration and Metadata
+
+Date: 2025-06-12
+
+## Status
+
+Accepted
+
+## Context
+
+Amux needs a format for storing:
+
+- Project configuration (`config.yaml`)
+- Workspace metadata
+- Session information
+- Agent definitions
+
+Requirements:
+
+- Human-readable and editable
+- Support for complex, nested structures
+- Comments for documentation
+- Wide language support
+- Standard in DevOps/cloud-native tools
+
+Options considered:
+
+1. **JSON** - JavaScript Object Notation
+2. **TOML** - Tom's Obvious, Minimal Language
+3. **YAML** - YAML Ain't Markup Language
+4. **HCL** - HashiCorp Configuration Language
+5. **INI** - Simple key-value format
+
+## Decision
+
+We will use YAML as the primary format for all configuration and metadata files.
+
+This includes:
+
+- `.amux/config.yaml` - Project configuration
+- `.amux/workspaces/workspace-*.yaml` - Workspace metadata
+- `.amux/sessions/session-*.yaml` - Session information
+- Embedded workspace metadata in `workspace.yaml`
+
+## Consequences
+
+### Positive
+
+- **Human-readable** - Easy to read and edit manually
+- **Comments** - Can document configuration inline
+- **Complex structures** - Supports nested objects and arrays naturally
+- **DevOps standard** - Familiar to users of Kubernetes, Docker Compose, etc.
+- **Good library support** - Mature parsing libraries in all languages
+- **Expressive** - Supports multi-line strings, references, etc.
+
+### Negative
+
+- **Parsing complexity** - YAML spec is complex, edge cases exist
+- **Indentation sensitivity** - Errors from incorrect indentation
+- **Performance** - Slower parsing than JSON
+- **Security concerns** - Some YAML parsers have had vulnerabilities
+- **Type ambiguity** - Strings vs numbers vs booleans can be unclear
+
+### Neutral
+
+- Requires YAML parsing library
+- Schema validation needs additional tooling
+- Different YAML versions have different features
+
+## Implementation Notes
+
+1. Use YAML 1.2 specification
+2. Avoid complex YAML features (anchors, tags) for simplicity
+3. Always quote strings that could be ambiguous
+4. Use consistent indentation (2 spaces)
+5. Validate schemas where possible
+6. Be careful with type conversions
+
+Example structure:
+
+```yaml
+# Clear comments explaining configuration
+amux:
+  version: 0.1.0
+  root_dir: .amux
+
+agents:
+  claude:
+    name: Claude
+    type: claude
+    command: claude
+    environment:
+      # Use ${} for environment variable substitution
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+```
+
+## Alternatives Considered
+
+### JSON
+
+**Pros**: Fast parsing, unambiguous, wide support
+**Cons**: No comments, verbose, not human-friendly, no multiline strings
+
+### TOML
+
+**Pros**: Human-friendly, clear types, good for flat configs
+**Cons**: Complex nested structures are awkward, less common in DevOps
+
+### HCL
+
+**Pros**: Good for infrastructure config, supports functions
+**Cons**: HashiCorp-specific, learning curve, overkill for our needs
+
+### INI
+
+**Pros**: Very simple, human-readable
+**Cons**: No nested structures, limited types, too simple for our needs
+
+## Migration Strategy
+
+If we need to migrate away from YAML:
+
+1. Implement new parser alongside YAML
+2. Add migration command
+3. Support both formats temporarily
+4. Deprecate YAML support
+5. Remove YAML parser
+
+## References
+
+- [YAML 1.2 Specification](https://yaml.org/spec/1.2/spec.html)
+- [YAML Best Practices](https://yaml.org/spec/1.2/spec.html#id2805071)
+- Go YAML v3 library documentation

--- a/docs/adr/014-file-based-session-store.md
+++ b/docs/adr/014-file-based-session-store.md
@@ -1,0 +1,138 @@
+# ADR-014: File-based Session Store
+
+Date: 2025-06-12
+
+## Status
+
+Accepted
+
+## Context
+
+Amux needs to persist session metadata across restarts. This includes:
+
+- Session ID and status
+- Associated workspace
+- Agent configuration
+- Start time and other metadata
+
+Requirements:
+
+- Simple implementation
+- No external dependencies
+- Easy debugging and inspection
+- Portable across systems
+- Consistent with other amux storage
+
+Options considered:
+
+1. **SQLite database** - Embedded SQL database
+2. **BoltDB/BadgerDB** - Embedded key-value stores
+3. **JSON files** - One file per session
+4. **YAML files** - One file per session (consistent with other storage)
+5. **Memory-only** - No persistence
+
+## Decision
+
+We will use a file-based session store with individual YAML files for each session.
+
+Implementation:
+
+- Store session files in `.amux/sessions/`
+- One YAML file per session: `session-{id}.yaml`
+- In-memory cache for performance
+- File system as source of truth
+
+## Consequences
+
+### Positive
+
+- **Simple implementation** - Just file I/O operations
+- **No dependencies** - No database libraries needed
+- **Easy debugging** - Can inspect/edit files directly
+- **Portable** - Works on any filesystem
+- **Consistent** - Same format as other amux data
+- **Recovery-friendly** - Can manually fix corrupted data
+- **Version control friendly** - Changes are trackable
+
+### Negative
+
+- **Race conditions** - Potential conflicts with concurrent access
+- **Limited querying** - No SQL-like queries, must scan files
+- **Performance at scale** - Listing many sessions requires reading many files
+- **No transactions** - No ACID guarantees
+- **Manual cleanup** - Orphaned files need detection
+
+### Neutral
+
+- File system performance characteristics apply
+- Backup/restore is just file copying
+- Migration requires file format changes
+
+## Implementation Notes
+
+1. Session files are named `session-{id}.yaml`
+2. Use file locking for write operations
+3. Implement in-memory cache with TTL
+4. Scan directory for listing operations
+5. Use atomic writes (write to temp, rename)
+
+Example session file:
+
+```yaml
+id: sess-abc123
+workspace_id: ws-xyz789
+agent_id: claude
+status: running
+tmux_session: amux-myworkspace-abc123
+created_at: 2024-01-15T10:30:00Z
+updated_at: 2024-01-15T10:35:00Z
+environment:
+  ANTHROPIC_API_KEY: "***"
+```
+
+## Alternatives Considered
+
+### SQLite Database
+
+**Pros**: ACID transactions, SQL queries, indexes, single file
+**Cons**: Dependency, migration complexity, debugging harder, overkill
+
+### BoltDB/BadgerDB
+
+**Pros**: Fast key-value operations, transactions, Go-native
+**Cons**: Binary format, debugging difficult, dependencies
+
+### JSON Files
+
+**Pros**: Simple, wide support
+**Cons**: No comments, less readable than YAML
+
+### Memory-only
+
+**Pros**: Fast, simple
+**Cons**: No persistence, sessions lost on restart
+
+## Future Migration Path
+
+If file-based storage becomes inadequate:
+
+1. Implement new store interface
+2. Add migration command
+3. Support both stores temporarily
+4. Gradually migrate sessions
+5. Remove file-based implementation
+
+The `SessionStore` interface makes this migration straightforward.
+
+## Performance Considerations
+
+- Cache frequently accessed sessions
+- Implement pagination for list operations
+- Consider sharding by date for many sessions
+- Monitor file system limits
+
+## References
+
+- File-based storage patterns
+- Go file locking best practices
+- [ADR-013: YAML for Configuration](013-yaml-for-configuration.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,12 @@ This directory contains Architecture Decision Records (ADRs) for the Amux projec
 6. [Context Management Strategy](006-context-management-strategy.md)
 7. [Table Library Selection](007-table-library-selection.md)
 8. [Session Mailbox System](008-session-mailbox-system.md)
+9. [MCP Resources and Prompts](009-mcp-resources-and-prompts.md)
+10. [Documentation Structure Strategy](010-documentation-structure.md)
+11. [Git Worktrees for Workspace Isolation](011-git-worktrees-for-workspace-isolation.md)
+12. [Tmux for Session Management](012-tmux-for-session-management.md)
+13. [YAML for Configuration](013-yaml-for-configuration.md)
+14. [File-based Session Store](014-file-based-session-store.md)
 
 ## What is an ADR?
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,10 +99,13 @@ agents:
 **Available Tools**:
 
 - `workspace_create` - Create new workspace
-- `workspace_list` - List workspaces
-- `workspace_get` - Get workspace details
 - `workspace_remove` - Remove workspace
-- `workspace_info` - Browse workspace files
+
+**Bridge Tools** (for clients without resource support):
+
+- `resource_workspace_list` - List all workspaces
+- `resource_workspace_show` - Get workspace details
+- `resource_workspace_browse` - Browse workspace files
 
 ## Data Flow
 
@@ -165,61 +168,22 @@ project-root/
 
 ```
 
-## Design Decisions
+## Design Philosophy
 
-### 1. Git Worktrees for Isolation
+Amux follows these architectural principles:
 
-**Rationale**:
+- **Simplicity over features** - Start simple, extend when needed
+- **No external services** - Everything runs locally
+- **Git-native workflows** - Leverage git's power
+- **File-based storage** - Easy debugging and inspection
+- **Clean interfaces** - Enable future extensibility
 
-- True filesystem isolation between agents
-- Parallel development without conflicts
-- Standard git workflows for merging
+For detailed design decisions and rationale, see:
 
-**Trade-offs**:
-
-- Disk space usage (full copy per workspace)
-- Complexity of worktree management
-
-### 2. Tmux for Session Management
-
-**Rationale**:
-
-- Persistent terminal sessions
-- Attach/detach capability
-- Standard tool in development environments
-
-**Trade-offs**:
-
-- Dependency on external tool
-- Platform-specific behavior
-- Fallback to basic sessions without tmux
-
-### 3. YAML for Configuration
-
-**Rationale**:
-
-- Human-readable and editable
-- Good for structured configuration
-- Standard in DevOps tools
-
-**Trade-offs**:
-
-- Parsing overhead
-- Schema validation complexity
-
-### 4. File-based Session Store
-
-**Rationale**:
-
-- Simple and portable
-- No database dependencies
-- Easy debugging and inspection
-
-**Trade-offs**:
-
-- Potential race conditions
-- Limited query capabilities
-- File system performance
+- [ADR-011: Git Worktrees for Workspace Isolation](adr/011-git-worktrees-for-workspace-isolation.md)
+- [ADR-012: Tmux for Session Management](adr/012-tmux-for-session-management.md)
+- [ADR-013: YAML for Configuration](adr/013-yaml-for-configuration.md)
+- [ADR-014: File-based Session Store](adr/014-file-based-session-store.md)
 
 ## Extension Points
 


### PR DESCRIPTION
## Summary

This PR establishes a clear documentation structure strategy and refactors `docs/architecture.md` to maintain separation between descriptive documentation and design decisions.

## Changes

### 1. Documentation Structure Strategy
- Created **ADR-010** to document our documentation structure decision
- Established clear boundaries:
  - ADRs: Document the "why" (immutable decision records)
  - architecture.md: Document the "what" (living document)
  - Component docs: Detailed technical reference

### 2. Documentation Guide
- Added `docs/README.md` as a guide for contributors
- Includes decision tree for where to document
- Provides examples and best practices

### 3. Extracted Design Decisions
Created new ADRs for decisions previously in architecture.md:
- **ADR-011**: Git Worktrees for Workspace Isolation
- **ADR-012**: Tmux for Session Management
- **ADR-013**: YAML for Configuration
- **ADR-014**: File-based Session Store

### 4. Refactored architecture.md
- Removed all design rationale and trade-offs sections
- Updated outdated tool information (removed workspace_list, workspace_get, workspace_info)
- Added correct MCP tools and bridge tools
- Added references to relevant ADRs for rationale
- Focused purely on descriptive content

### 5. Updated Cross-references
- Updated main README.md to reference docs/README.md
- Updated ADR index to include new ADRs
- Added cross-references between related documents

## Benefits

- ✅ Clear separation of concerns between decision records and current state
- ✅ ADRs remain focused on decisions and rationale
- ✅ Architecture documentation can evolve without affecting decision history
- ✅ Contributors have clear guidance on where to document
- ✅ Reduced redundancy and maintenance burden
- ✅ Better discoverability of information

## Test Plan

- [x] All existing tests pass
- [x] Documentation builds correctly
- [x] Links between documents work
- [x] Markdown linting passes

Closes #57