### PR TITLE
docs: separate CLAUDE.md into project rules and personal workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 # Lefthook
 .lefthook-local.yml
 
+# Local configuration
+CLAUDE.local.md
+
 # Test artifacts
 test-*-repo/
 *.test


### PR DESCRIPTION
## Summary

This PR separates CLAUDE.md into two distinct files:
- **CLAUDE.md** - Project-wide development standards (committed to repo)
- **CLAUDE.local.md** - Personal workflow preferences (excluded from git)

## Changes

1. **Updated CLAUDE.md** to contain only project-wide information:
   - Project overview and features
   - Development standards and code guidelines
   - Pull request guidelines
   - Essential commands and troubleshooting
   - Added `@CLAUDE.local.md` reference at the end

2. **Created CLAUDE.local.md** (not in this PR, excluded from git) containing:
   - Personal dogfooding workflow
   - AI agent workflow with MCP tools
   - Workspace management safety rules
   - Personal preferences

3. **Updated .gitignore** to exclude CLAUDE.local.md

## Benefits

- **Separation of concerns**: Project rules vs personal preferences
- **Better collaboration**: All developers see the same project standards
- **Privacy**: Personal workflows and paths remain local
- **Flexibility**: Each developer can customize their CLAUDE.local.md

## How it works

Claude Code will load both files:
1. First loads CLAUDE.md for project standards
2. Then loads CLAUDE.local.md (via @reference) for personal preferences

This allows maintaining consistent project standards while enabling personal customization.