### PR TITLE
fix: exclude .amux directory from all linting and formatting checks (#73)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ version: '2'
 run:
   timeout: 5m
   tests: true
+  skip-dirs:
+    - .amux
 formatters:
   enable:
     - goimports

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -22,3 +22,4 @@ exclude:
   - "vendor/**"
   - "node_modules/**"
   - "**/testdata/**"
+  - ".amux/**"

--- a/justfile
+++ b/justfile
@@ -127,11 +127,11 @@ fmt-whitespace *files:
     if [ -z "{{files}}" ]; then
         # Remove trailing spaces
         find . -type f \( -name "*.go" -o -name "*.md" -o -name "*.yml" -o -name "*.yaml" -o -name "*.txt" -o -name "*.json" -o -name "*.toml" -o -name "*.mod" -o -name "*.sum" -o -name "justfile" \) \
-            -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" \
+            -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" -not -path "./.amux/*" \
             -exec perl -i -pe 's/[ \t]+$//' {} \;
         # Ensure newline at EOF
         find . -type f \( -name "*.go" -o -name "*.md" -o -name "*.yml" -o -name "*.yaml" -o -name "*.txt" -o -name "*.json" -o -name "*.toml" -o -name "*.mod" -o -name "*.sum" -o -name "justfile" \) \
-            -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" \
+            -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" -not -path "./.amux/*" \
             -exec sh -c '[ "$(tail -c1 "$1")" != "" ] && echo >> "$1" || true' _ {} \;
     else
         # Process specific files

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Private development caves for AI agents",
   "private": true,
   "scripts": {
-    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#.amux'",
     "lint:commit": "commitlint --from HEAD~1 --to HEAD",
-    "fix:md": "markdownlint-cli2 --fix '**/*.md' '#node_modules'"
+    "fix:md": "markdownlint-cli2 --fix '**/*.md' '#node_modules' '#.amux'"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
@@ -21,7 +21,8 @@
       "node_modules/**",
       ".git/**",
       "bin/**",
-      "coverage/**"
+      "coverage/**",
+      ".amux/**"
     ],
     "config": {
       "default": true,


### PR DESCRIPTION
## Summary

- Added .amux directory to exclusion lists in all linting and formatting tools
- Ensures temporary workspace files don't interfere with code quality checks
- Fixes #73 

## Changes

- **`.golangci.yml`**: Added `.amux` to `skip-dirs` configuration
- **`.yamlfmt`**: Added `.amux/**` to exclude patterns
- **`package.json`**: Added `.amux/**` to markdownlint-cli2 ignores and updated scripts
- **`justfile`**: Added `-not -path "./.amux/*"` to all find commands

## Test Plan

- [x] Run `just fmt` - verifies formatting commands ignore .amux
- [x] Run `just lint` - verifies linting commands ignore .amux  
- [x] Run `just check` - verifies all checks pass
- [x] Create test files in .amux and verify they're ignored