### PR TITLE
feat: add --format option for structured output (#84)

### DIFF
--- a/internal/cli/commands/root.go
+++ b/internal/cli/commands/root.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"github.com/aki/amux/internal/cli/ui"
 	"github.com/spf13/cobra"
 )
+
+var formatFlag string
 
 var rootCmd = &cobra.Command{
 	Use: "amux",
@@ -13,9 +16,21 @@ var rootCmd = &cobra.Command{
 
 can work independently without context mixing. It enables multiplexing multiple agent sessions
 across different workspaces.`,
+
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Parse and set the global formatter
+		format, err := ui.ParseFormat(formatFlag)
+		if err != nil {
+			return err
+		}
+		return ui.SetGlobalFormatter(format)
+	},
 }
 
 func init() {
+	// Add global flags
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "pretty", "Output format (pretty, json)")
+
 	// Add subcommands
 
 	rootCmd.AddCommand(initCmd)

--- a/internal/cli/commands/version.go
+++ b/internal/cli/commands/version.go
@@ -19,6 +19,23 @@ var versionCmd = &cobra.Command{
 	Short: "Show version information",
 	Long:  "Display detailed version information about amux",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Handle JSON output
+		if ui.GlobalFormatter.IsJSON() {
+			versionInfo := map[string]string{
+				"version":   Version,
+				"gitCommit": GitCommit,
+				"buildDate": BuildDate,
+				"goVersion": runtime.Version(),
+				"os":        runtime.GOOS,
+				"arch":      runtime.GOARCH,
+			}
+			if err := ui.GlobalFormatter.Output(versionInfo); err != nil {
+				return
+			}
+			return
+		}
+
+		// Pretty output
 		ui.OutputLine("amux version %s", Version)
 		ui.OutputLine("  Git commit: %s", GitCommit)
 		ui.OutputLine("  Build date: %s", BuildDate)

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -217,6 +217,12 @@ func runListWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list workspaces: %w", err)
 	}
 
+	// Handle JSON output
+	if ui.GlobalFormatter.IsJSON() {
+		return ui.GlobalFormatter.Output(workspaces)
+	}
+
+	// Handle pretty output
 	if listOneline {
 		// One line per workspace for fzf integration
 
@@ -256,6 +262,11 @@ func runShowWorkspace(cmd *cobra.Command, args []string) error {
 	ws, err := manager.ResolveWorkspace(identifier)
 	if err != nil {
 		return fmt.Errorf("failed to resolve workspace: %w", err)
+	}
+
+	// Handle JSON output
+	if ui.GlobalFormatter.IsJSON() {
+		return ui.GlobalFormatter.Output(ws)
 	}
 
 	// Print detailed workspace information

--- a/internal/cli/ui/formatter.go
+++ b/internal/cli/ui/formatter.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// OutputFormat represents the output format type
+type OutputFormat string
+
+const (
+	// FormatPretty represents human-readable output format
+	FormatPretty OutputFormat = "pretty"
+	// FormatJSON represents JSON output format
+	FormatJSON OutputFormat = "json"
+)
+
+// ParseFormat converts a string to OutputFormat
+func ParseFormat(s string) (OutputFormat, error) {
+	switch s {
+	case "pretty", "":
+		return FormatPretty, nil
+	case "json":
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported format: %s", s)
+	}
+}
+
+// Formatter is the interface for output formatting
+type Formatter interface {
+	// Output formats and displays any data
+	Output(data interface{}) error
+
+	// OutputError formats and displays an error
+	OutputError(err error) error
+
+	// IsJSON returns true if this formatter outputs JSON
+	IsJSON() bool
+}
+
+// prettyFormatter implements Formatter for human-readable output
+type prettyFormatter struct{}
+
+// NewPrettyFormatter creates a new pretty formatter
+func NewPrettyFormatter() Formatter {
+	return &prettyFormatter{}
+}
+
+func (f *prettyFormatter) Output(data interface{}) error {
+	// For pretty format, we expect data to be already formatted
+	// This is just a passthrough that prints the data
+	if str, ok := data.(string); ok {
+		fmt.Print(str)
+		return nil
+	}
+
+	// For other types, use default formatting
+	fmt.Println(data)
+	return nil
+}
+
+func (f *prettyFormatter) OutputError(err error) error {
+	// Pretty formatter outputs errors to stderr with formatting
+	fmt.Fprintf(os.Stderr, "%s %s\n", ErrorIcon, ErrorStyle.Render(err.Error()))
+	return nil
+}
+
+func (f *prettyFormatter) IsJSON() bool {
+	return false
+}
+
+// jsonFormatter implements Formatter for JSON output
+type jsonFormatter struct {
+	encoder *json.Encoder
+}
+
+// NewJSONFormatter creates a new JSON formatter
+func NewJSONFormatter() Formatter {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return &jsonFormatter{encoder: encoder}
+}
+
+func (f *jsonFormatter) Output(data interface{}) error {
+	return f.encoder.Encode(data)
+}
+
+func (f *jsonFormatter) OutputError(err error) error {
+	// For JSON format, we still output errors to stderr as plain text
+	// This maintains compatibility with scripts that expect errors on stderr
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	return nil
+}
+
+func (f *jsonFormatter) IsJSON() bool {
+	return true
+}
+
+// GlobalFormatter is the global formatter instance
+var GlobalFormatter Formatter = NewPrettyFormatter()
+
+// SetGlobalFormatter sets the global formatter
+func SetGlobalFormatter(format OutputFormat) error {
+	switch format {
+	case FormatPretty:
+		GlobalFormatter = NewPrettyFormatter()
+	case FormatJSON:
+		GlobalFormatter = NewJSONFormatter()
+	default:
+		return fmt.Errorf("unsupported format: %s", format)
+	}
+	return nil
+}
+
+// WithFormatter temporarily sets a formatter for a function execution
+func WithFormatter(format OutputFormat, fn func() error) error {
+	oldFormatter := GlobalFormatter
+	defer func() { GlobalFormatter = oldFormatter }()
+
+	if err := SetGlobalFormatter(format); err != nil {
+		return err
+	}
+
+	return fn()
+}

--- a/internal/cli/ui/formatter_test.go
+++ b/internal/cli/ui/formatter_test.go
@@ -1,0 +1,156 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      OutputFormat
+		wantError bool
+	}{
+		{
+			name:  "empty string defaults to pretty",
+			input: "",
+			want:  FormatPretty,
+		},
+		{
+			name:  "pretty format",
+			input: "pretty",
+			want:  FormatPretty,
+		},
+		{
+			name:  "json format",
+			input: "json",
+			want:  FormatJSON,
+		},
+		{
+			name:      "invalid format",
+			input:     "xml",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFormat(tt.input)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ParseFormat() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONFormatter_Output(t *testing.T) {
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	formatter := NewJSONFormatter()
+
+	// Test data
+	testData := map[string]string{
+		"name":    "test",
+		"version": "1.0.0",
+	}
+
+	// Write output
+	err := formatter.Output(testData)
+	if err != nil {
+		t.Fatalf("Output() error = %v", err)
+	}
+
+	// Restore stdout and read output
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	// Verify JSON output
+	var result map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	if result["name"] != "test" || result["version"] != "1.0.0" {
+		t.Errorf("Unexpected JSON output: %v", result)
+	}
+}
+
+func TestJSONFormatter_IsJSON(t *testing.T) {
+	jsonFormatter := NewJSONFormatter()
+	if !jsonFormatter.IsJSON() {
+		t.Error("JSONFormatter.IsJSON() should return true")
+	}
+
+	prettyFormatter := NewPrettyFormatter()
+	if prettyFormatter.IsJSON() {
+		t.Error("PrettyFormatter.IsJSON() should return false")
+	}
+}
+
+func TestSetGlobalFormatter(t *testing.T) {
+	// Save original formatter
+	original := GlobalFormatter
+	defer func() { GlobalFormatter = original }()
+
+	// Test setting JSON formatter
+	err := SetGlobalFormatter(FormatJSON)
+	if err != nil {
+		t.Fatalf("SetGlobalFormatter(FormatJSON) error = %v", err)
+	}
+	if !GlobalFormatter.IsJSON() {
+		t.Error("GlobalFormatter should be JSON formatter")
+	}
+
+	// Test setting pretty formatter
+	err = SetGlobalFormatter(FormatPretty)
+	if err != nil {
+		t.Fatalf("SetGlobalFormatter(FormatPretty) error = %v", err)
+	}
+	if GlobalFormatter.IsJSON() {
+		t.Error("GlobalFormatter should be pretty formatter")
+	}
+}
+
+func TestWithFormatter(t *testing.T) {
+	// Save original formatter
+	original := GlobalFormatter
+	defer func() { GlobalFormatter = original }()
+
+	// Set initial formatter to pretty
+	GlobalFormatter = NewPrettyFormatter()
+
+	// Use WithFormatter to temporarily switch to JSON
+	executed := false
+	err := WithFormatter(FormatJSON, func() error {
+		executed = true
+		if !GlobalFormatter.IsJSON() {
+			t.Error("GlobalFormatter should be JSON within function")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithFormatter() error = %v", err)
+	}
+
+	if !executed {
+		t.Error("Function was not executed")
+	}
+
+	// Verify formatter was restored
+	if GlobalFormatter.IsJSON() {
+		t.Error("GlobalFormatter should be restored to pretty formatter")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a global `--format` flag to all amux commands
- Supports `pretty` (default) and `json` output formats
- Enables programmatic use of amux through structured JSON output

## Changes

1. **Added formatter interface** (`internal/cli/ui/formatter.go`):
   - `Formatter` interface with `Output()`, `OutputError()`, and `IsJSON()` methods
   - `prettyFormatter` for human-readable output (default)
   - `jsonFormatter` for structured JSON output
   - Global formatter instance that can be set via the format flag

2. **Updated commands**:
   - Added `--format` persistent flag to root command
   - Updated `ws list`, `ws show`, and `version` commands to check formatter and output JSON when requested
   - Maintained backward compatibility - pretty format is the default

3. **Added comprehensive tests** for the formatter functionality

## Test Plan

- [x] Run `amux version --format json` - outputs version info as JSON
- [x] Run `amux ws list --format json` - outputs workspace list as JSON array
- [x] Run `amux ws show <id> --format json` - outputs single workspace as JSON object
- [x] Verify default behavior unchanged (no --format flag = pretty output)
- [x] Run test suite - all tests pass
- [x] Run linter - no issues

## Examples

```bash
# JSON output
$ amux version --format json
{
  "arch": "arm64",
  "buildDate": "2025-06-12T09:54:20Z",
  "gitCommit": "61a17f8",
  "goVersion": "go1.24.4",
  "os": "darwin",
  "version": "61a17f8-dirty"
}

# Workspace list
$ amux ws list --format json
[
  {
    "id": "workspace-feat-format-option-1749721485-6ff7fc60",
    "index": "5",
    "name": "feat-format-option",
    "branch": "amux/workspace-feat-format-option-1749721485-6ff7fc60",
    "baseBranch": "main",
    "path": "/path/to/workspace",
    "description": "Add --format option for structured output (#84)",
    "createdAt": "2025-06-12T18:44:45.323126+09:00",
    "updatedAt": "2025-06-12T18:54:21.667735622+09:00",
    "pathExists": true,
    "worktreeExists": true,
    "status": "consistent"
  }
]
```

Closes #84