### PR TITLE
docs: update PR guidelines to exclude issue refs from titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ return fmt.Errorf("Workspace not found.")  // Bad
 - **Always create draft PRs** using `gh pr create --draft`
 - **Never push directly to main branch**
 - **Create feature branches** in workspaces using amux
-- **Include issue references** in PR titles and descriptions
+- **Include issue references** in PR descriptions (NOT in titles)
 - **Run all checks** before creating PR (`just check && just test`)
 
 ## Important Notes


### PR DESCRIPTION
## Summary

Update CLAUDE.md to clarify that issue references should only be included in PR descriptions, not in PR titles.

## Changes

- Modified PR guidelines in CLAUDE.md to specify "(NOT in titles)" for issue references
- This aligns with the user's preference for cleaner PR titles

## Test plan

Documentation change only - no testing required.