### PR TITLE
feat: enable auto-workspace creation for quick starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ This creates:
 # Initialize project
 amux init
 
-# Create a workspace and run an agent
-amux ws create feature-auth --agent claude
+# Run an agent (auto-creates workspace if needed)
 amux run claude
+
+# Or create a specific workspace first
+amux ws create feature-auth
+amux run claude --workspace feature-auth
 
 # Check running sessions
 amux ps

--- a/internal/cli/commands/agent.go
+++ b/internal/cli/commands/agent.go
@@ -127,21 +127,17 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create workspace manager: %w", err)
 	}
 
+	// Generate session ID upfront
+	sessionID := session.GenerateID()
+
 	// Get or select workspace
 	var ws *workspace.Workspace
-	var sessionID session.ID
-
 	if runWorkspace != "" {
 		ws, err = wsManager.ResolveWorkspace(runWorkspace)
 		if err != nil {
 			return fmt.Errorf("failed to resolve workspace: %w", err)
 		}
-		// Generate session ID for specified workspace
-		sessionID = session.GenerateID()
 	} else {
-		// Generate session ID first for auto-created workspace
-		sessionID = session.GenerateID()
-
 		// Auto-create a new workspace using session ID
 		ws, err = createAutoWorkspace(wsManager, sessionID)
 		if err != nil {

--- a/internal/cli/commands/agent.go
+++ b/internal/cli/commands/agent.go
@@ -206,13 +206,8 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		sessionID = info.Index
 	}
 
-	// Show session creation info with workspace ID for auto-created workspaces
-	if runWorkspace == "" {
-		// Auto-created workspace - show workspace ID
-		ui.Success("Started session: %s in workspace %s", sessionID, ws.Index)
-	} else {
-		ui.Info("Created session %s for agent '%s' in workspace '%s'", sessionID, agentID, ws.Name)
-	}
+	// Show consistent session creation info
+	ui.Success("Started session: %s in workspace %s", sessionID, ws.Index)
 
 	// Start session
 	ctx := context.Background()

--- a/internal/cli/commands/agent.go
+++ b/internal/cli/commands/agent.go
@@ -140,7 +140,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create auto-workspace: %w", err)
 		}
-		ui.Success("Created workspace: %s", ws.Index)
+		ui.Success("Created workspace: '%s'", ws.Name)
 	}
 
 	// Create agent manager
@@ -206,8 +206,8 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		sessionID = info.Index
 	}
 
-	// Show consistent session creation info
-	ui.Success("Started session: %s in workspace %s", sessionID, ws.Index)
+	// Show consistent session creation info with workspace name
+	ui.Success("Started session: %s in workspace '%s'", sessionID, ws.Name)
 
 	// Start session
 	ctx := context.Background()

--- a/internal/cli/commands/agent_test.go
+++ b/internal/cli/commands/agent_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/tests/helpers"
+)
+
+func TestCreateAutoWorkspace(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingWS      []string
+		expectedName    string
+		expectedPattern string
+	}{
+		{
+			name:         "first auto workspace",
+			existingWS:   []string{},
+			expectedName: "auto-1",
+		},
+		{
+			name:         "second auto workspace",
+			existingWS:   []string{"auto-1"},
+			expectedName: "auto-2",
+		},
+		{
+			name:         "with gap in numbering",
+			existingWS:   []string{"auto-1", "auto-3"},
+			expectedName: "auto-2",
+		},
+		{
+			name:         "multiple existing",
+			existingWS:   []string{"auto-1", "auto-2", "auto-3"},
+			expectedName: "auto-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test repository
+			repoDir := helpers.CreateTestRepo(t)
+			defer os.RemoveAll(repoDir)
+
+			// Initialize Amux
+			configManager := config.NewManager(repoDir)
+			cfg := config.DefaultConfig()
+			err := configManager.Save(cfg)
+			require.NoError(t, err)
+
+			// Create workspace manager
+			wsManager, err := workspace.NewManager(configManager)
+			require.NoError(t, err)
+
+			// Create existing workspaces
+			for _, name := range tt.existingWS {
+				opts := workspace.CreateOptions{
+					Name:        name,
+					Description: "Test workspace",
+					BaseBranch:  "main",
+				}
+				_, err := wsManager.Create(opts)
+				require.NoError(t, err)
+			}
+
+			// Test auto workspace creation
+			ws, err := createAutoWorkspace(wsManager)
+			require.NoError(t, err)
+			assert.NotNil(t, ws)
+			assert.Equal(t, tt.expectedName, ws.Name)
+			assert.Equal(t, "Auto-created workspace", ws.Description)
+			assert.Equal(t, "main", ws.BaseBranch)
+		})
+	}
+}

--- a/internal/cli/commands/agent_test.go
+++ b/internal/cli/commands/agent_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -8,73 +9,69 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
 	"github.com/aki/amux/internal/tests/helpers"
 )
 
 func TestCreateAutoWorkspace(t *testing.T) {
-	tests := []struct {
-		name            string
-		existingWS      []string
-		expectedName    string
-		expectedPattern string
-	}{
-		{
-			name:         "first auto workspace",
-			existingWS:   []string{},
-			expectedName: "auto-1",
-		},
-		{
-			name:         "second auto workspace",
-			existingWS:   []string{"auto-1"},
-			expectedName: "auto-2",
-		},
-		{
-			name:         "with gap in numbering",
-			existingWS:   []string{"auto-1", "auto-3"},
-			expectedName: "auto-2",
-		},
-		{
-			name:         "multiple existing",
-			existingWS:   []string{"auto-1", "auto-2", "auto-3"},
-			expectedName: "auto-4",
-		},
-	}
+	// Create test repository
+	repoDir := helpers.CreateTestRepo(t)
+	defer os.RemoveAll(repoDir)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create test repository
-			repoDir := helpers.CreateTestRepo(t)
-			defer os.RemoveAll(repoDir)
+	// Initialize Amux
+	configManager := config.NewManager(repoDir)
+	cfg := config.DefaultConfig()
+	err := configManager.Save(cfg)
+	require.NoError(t, err)
 
-			// Initialize Amux
-			configManager := config.NewManager(repoDir)
-			cfg := config.DefaultConfig()
-			err := configManager.Save(cfg)
-			require.NoError(t, err)
+	// Create workspace manager
+	wsManager, err := workspace.NewManager(configManager)
+	require.NoError(t, err)
 
-			// Create workspace manager
-			wsManager, err := workspace.NewManager(configManager)
-			require.NoError(t, err)
+	// Generate a test session ID
+	sessionID := session.GenerateID()
 
-			// Create existing workspaces
-			for _, name := range tt.existingWS {
-				opts := workspace.CreateOptions{
-					Name:        name,
-					Description: "Test workspace",
-					BaseBranch:  "main",
-				}
-				_, err := wsManager.Create(opts)
-				require.NoError(t, err)
-			}
+	// Test auto workspace creation
+	ws, err := createAutoWorkspace(wsManager, sessionID)
+	require.NoError(t, err)
+	assert.NotNil(t, ws)
 
-			// Test auto workspace creation
-			ws, err := createAutoWorkspace(wsManager)
-			require.NoError(t, err)
-			assert.NotNil(t, ws)
-			assert.Equal(t, tt.expectedName, ws.Name)
-			assert.Equal(t, "Auto-created workspace", ws.Description)
-			assert.Equal(t, "main", ws.BaseBranch)
-		})
-	}
+	// Expected name format: session-{first-8-chars-of-uuid}
+	expectedName := fmt.Sprintf("session-%s", sessionID.Short())
+	assert.Equal(t, expectedName, ws.Name)
+	assert.Contains(t, ws.Description, "Auto-created workspace for session")
+	assert.Contains(t, ws.Description, sessionID.Short())
+	assert.Equal(t, "main", ws.BaseBranch)
+}
+
+func TestCreateAutoWorkspaceUniqueness(t *testing.T) {
+	// Create test repository
+	repoDir := helpers.CreateTestRepo(t)
+	defer os.RemoveAll(repoDir)
+
+	// Initialize Amux
+	configManager := config.NewManager(repoDir)
+	cfg := config.DefaultConfig()
+	err := configManager.Save(cfg)
+	require.NoError(t, err)
+
+	// Create workspace manager
+	wsManager, err := workspace.NewManager(configManager)
+	require.NoError(t, err)
+
+	// Create multiple workspaces with different session IDs
+	sessionID1 := session.GenerateID()
+	sessionID2 := session.GenerateID()
+
+	ws1, err := createAutoWorkspace(wsManager, sessionID1)
+	require.NoError(t, err)
+
+	ws2, err := createAutoWorkspace(wsManager, sessionID2)
+	require.NoError(t, err)
+
+	// Ensure workspace names are different
+	assert.NotEqual(t, ws1.Name, ws2.Name)
+	assert.Equal(t, fmt.Sprintf("session-%s", sessionID1.Short()), ws1.Name)
+	assert.Equal(t, fmt.Sprintf("session-%s", sessionID2.Short()), ws2.Name)
 }

--- a/internal/core/session/types.go
+++ b/internal/core/session/types.go
@@ -3,7 +3,35 @@ package session
 import (
 	"context"
 	"time"
+
+	"github.com/google/uuid"
 )
+
+// ID represents a unique session identifier
+type ID string
+
+// GenerateID generates a new unique session ID
+func GenerateID() ID {
+	return ID(uuid.New().String())
+}
+
+// String returns the string representation of the session ID
+func (id ID) String() string {
+	return string(id)
+}
+
+// Short returns the first 8 characters of the session ID
+func (id ID) Short() string {
+	if len(id) >= 8 {
+		return string(id[:8])
+	}
+	return string(id)
+}
+
+// IsEmpty returns true if the ID is empty
+func (id ID) IsEmpty() bool {
+	return id == ""
+}
 
 // Status represents the current state of a session
 type Status string
@@ -21,6 +49,7 @@ const (
 
 // Options contains options for creating a new session
 type Options struct {
+	ID          ID                // Optional: pre-generated session ID
 	WorkspaceID string            // Required: workspace to run in
 	AgentID     string            // Required: agent to run
 	Command     string            // Optional: override agent command


### PR DESCRIPTION
## Summary

Implements auto-workspace creation when running `amux run` without specifying a workspace. This lowers the barrier to entry for new users and enables quick experimentation.

Closes #5

## Changes

- **Auto-workspace creation**: When no `-w/--workspace` flag is provided, automatically creates a new workspace
- **Session-based naming**: Workspace names use format `session-{first-8-chars}` to show clear relationship with the session
- **Type-safe session IDs**: Added dedicated `session.ID` type with proper methods (String, Short, IsEmpty)
- **Pre-generated IDs**: Session ID is generated before workspace creation to establish the relationship
- **User-friendly output**: Shows workspace names instead of IDs for better readability
- **Consistent messaging**: Uses the same output format whether workspace is auto-created or specified
- **Updated documentation**: Help text and README updated to reflect the new behavior

## Test Plan

- [x] Added unit tests for auto-workspace creation logic
- [x] Tests verify session-based naming behavior  
- [x] All existing tests continue to pass
- [x] Pre-commit hooks pass (formatting, linting)

## Example Usage

```bash
# Auto-creates workspace with session-based name
$ amux run claude
✅ Created workspace: 'session-f47ac10b'
✅ Started session: 1 in workspace 'session-f47ac10b'

# Still supports explicit workspace
$ amux run claude --workspace feature-auth
✅ Started session: 2 in workspace 'feature-auth'
```

## Architecture Benefits

- **Clear relationship**: Easy to see which workspace belongs to which session
- **Type safety**: Dedicated `session.ID` type prevents string mixing
- **Extensibility**: Session ID can be used for other features (logging, telemetry)
- **No collisions**: UUID-based names guarantee uniqueness