### PR TITLE
docs: update work in progress warning to alpha release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ their lifecycle.
 For v0.1.0, we recommend starting with the workspace features which provide stable, isolated development environments.
 
 > [!WARNING]
-> **🚧 Work in Progress**
+> **🚧 Alpha Release**
 >
-> This project is actively being developed. Expect frequent updates and potential breaking changes.
+> This software is in alpha stage. Features may be incomplete, unstable, or change significantly.
+> Expect bugs and breaking changes until the 1.0 release.
 
 ## 🚀 Features
 


### PR DESCRIPTION
## Summary

- Updated README warning section from "Work in Progress" to "Alpha Release"
- Clarified that the software is in alpha stage with potential instability
- Added note about expecting stability at 1.0 release

## Changes

Changed the warning to be more explicit about the project's alpha status, making it clear that:
- Features may be incomplete or unstable
- Breaking changes should be expected
- Stability will come with the 1.0 release