### PR TITLE
fix: remove mock session implementation and require tmux adapter

### DIFF
--- a/internal/core/session/mock_test.go
+++ b/internal/core/session/mock_test.go
@@ -197,13 +197,13 @@ func TestManager_WithUnavailableTmux(t *testing.T) {
 		AgentID:     "test-agent",
 	}
 
-	session, err := manager.CreateSession(opts)
-	if err != nil {
-		t.Fatalf("Failed to create session: %v", err)
+	_, err = manager.CreateSession(opts)
+	if err == nil {
+		t.Fatal("Expected error when creating session with unavailable tmux")
 	}
 
-	// Should create a basic session when tmux unavailable
-	if _, ok := session.(*sessionImpl); !ok {
-		t.Error("Expected basic session when tmux unavailable")
+	// Should return ErrTmuxNotAvailable
+	if _, ok := err.(ErrTmuxNotAvailable); !ok {
+		t.Errorf("Expected ErrTmuxNotAvailable, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses issue #95 by removing the mock session implementation and making tmux a hard requirement for session operations.

## Changes

- Removed the `sessionImpl` struct and all its methods from `manager.go`
- Updated `CreateSession` to fail fast with `ErrTmuxNotAvailable` when tmux is not available
- Updated `createSessionFromInfo` to also require tmux (used when loading existing sessions)
- Added comprehensive tests to verify tmux requirement is enforced
- Updated existing tests that relied on the fallback behavior

## Test Plan

- [x] All existing tests pass
- [x] Added `TestManager_CreateSessionWithoutTmux` to verify session creation fails without tmux
- [x] Added `TestManager_GetSessionWithoutTmux` to verify session retrieval fails without tmux
- [x] Updated `TestManager_WithUnavailableTmux` to expect proper error handling
- [x] Run `just test` - all tests pass
- [x] Run `just check` - linting and formatting pass

Fixes #95