### PR TITLE
fix: recalculate terminal size when attaching to session (#116)

### DIFF
--- a/internal/cli/commands/session/attach.go
+++ b/internal/cli/commands/session/attach.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aki/amux/internal/core/config"
 	"github.com/aki/amux/internal/core/logger"
 	"github.com/aki/amux/internal/core/session"
+	"github.com/aki/amux/internal/core/terminal"
 	"github.com/aki/amux/internal/core/workspace"
 )
 
@@ -68,7 +69,7 @@ func attachSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Detect current terminal size and resize tmux window
-	width, height := session.GetTerminalSize()
+	width, height := terminal.GetSize()
 	tmuxAdapter, err := tmux.NewAdapter()
 	if err == nil {
 		// Create a logger for debugging

--- a/internal/cli/commands/session/attach.go
+++ b/internal/cli/commands/session/attach.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
 
 	"github.com/aki/amux/internal/adapters/tmux"
@@ -27,24 +26,6 @@ Use Ctrl-B D to detach from the session without stopping it.`,
 		Args: cobra.ExactArgs(1),
 		RunE: attachSession,
 	}
-}
-
-// getTerminalSize returns the current terminal dimensions or defaults
-func getTerminalSize() (width, height int) {
-	// Default dimensions
-	width, height = 120, 40
-
-	// Try to get terminal size from stdout
-	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
-		width, height = w, h
-		return
-	}
-
-	// Try stderr as fallback
-	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
-		width, height = w, h
-	}
-	return
 }
 
 func attachSession(cmd *cobra.Command, args []string) error {
@@ -87,7 +68,7 @@ func attachSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Detect current terminal size and resize tmux window
-	width, height := getTerminalSize()
+	width, height := session.GetTerminalSize()
 	tmuxAdapter, err := tmux.NewAdapter()
 	if err == nil {
 		// Create a logger for debugging

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -271,22 +271,29 @@ func (s *tmuxSessionImpl) getDefaultCommand() string {
 	}
 }
 
-// getTerminalSize returns the current terminal dimensions or defaults
-func (s *tmuxSessionImpl) getTerminalSize() (width, height int) {
+// GetTerminalSize returns the current terminal dimensions or defaults
+func GetTerminalSize() (width, height int) {
 	// Default dimensions
 	width, height = 120, 40
 
 	// Try to get terminal size from stdout
 	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
-		s.logger.Debug("detected terminal size", "width", width, "height", height)
 		return
 	}
 
 	// Try stderr as fallback
 	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
-		s.logger.Debug("detected terminal size from stderr", "width", width, "height", height)
+	}
+	return
+}
+
+// getTerminalSize returns the current terminal dimensions or defaults
+func (s *tmuxSessionImpl) getTerminalSize() (width, height int) {
+	width, height = GetTerminalSize()
+	if width != 120 || height != 40 {
+		s.logger.Debug("detected terminal size", "width", width, "height", height)
 	}
 	return
 }

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -121,9 +121,6 @@ func (s *tmuxSessionImpl) Start(ctx context.Context) error {
 
 	// Resize to terminal dimensions or use defaults
 	width, height := GetTerminalSize()
-	if width != 120 || height != 40 {
-		s.logger.Debug("detected terminal size", "width", width, "height", height)
-	}
 	if err := s.tmuxAdapter.ResizeWindow(tmuxSession, width, height); err != nil {
 		// Log warning but don't fail - resize is not critical
 		s.logger.Warn("failed to resize tmux window", "error", err, "session", tmuxSession)
@@ -282,12 +279,14 @@ func GetTerminalSize() (width, height int) {
 	// Try to get terminal size from stdout
 	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
+		logger.Default().Debug("detected terminal size from stdout", "width", width, "height", height)
 		return
 	}
 
 	// Try stderr as fallback
 	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
+		logger.Default().Debug("detected terminal size from stderr", "width", width, "height", height)
 	}
 	return
 }

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -279,14 +279,12 @@ func GetTerminalSize() (width, height int) {
 	// Try to get terminal size from stdout
 	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
-		logger.Default().Debug("detected terminal size from stdout", "width", width, "height", height)
 		return
 	}
 
 	// Try stderr as fallback
 	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
-		logger.Default().Debug("detected terminal size from stderr", "width", width, "height", height)
 	}
 	return
 }

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -3,15 +3,14 @@ package session
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/aki/amux/internal/adapters/tmux"
 	"github.com/aki/amux/internal/core/logger"
+	"github.com/aki/amux/internal/core/terminal"
 	"github.com/aki/amux/internal/core/workspace"
-	"github.com/charmbracelet/x/term"
 )
 
 // tmuxSessionImpl implements Session interface with tmux backend
@@ -120,7 +119,7 @@ func (s *tmuxSessionImpl) Start(ctx context.Context) error {
 	}
 
 	// Resize to terminal dimensions or use defaults
-	width, height := GetTerminalSize()
+	width, height := terminal.GetSize()
 	if err := s.tmuxAdapter.ResizeWindow(tmuxSession, width, height); err != nil {
 		// Log warning but don't fail - resize is not critical
 		s.logger.Warn("failed to resize tmux window", "error", err, "session", tmuxSession)
@@ -269,22 +268,4 @@ func (s *tmuxSessionImpl) getDefaultCommand() string {
 		// No default command for unknown agents
 		return ""
 	}
-}
-
-// GetTerminalSize returns the current terminal dimensions or defaults
-func GetTerminalSize() (width, height int) {
-	// Default dimensions
-	width, height = 120, 40
-
-	// Try to get terminal size from stdout
-	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
-		width, height = w, h
-		return
-	}
-
-	// Try stderr as fallback
-	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
-		width, height = w, h
-	}
-	return
 }

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -120,7 +120,10 @@ func (s *tmuxSessionImpl) Start(ctx context.Context) error {
 	}
 
 	// Resize to terminal dimensions or use defaults
-	width, height := s.getTerminalSize()
+	width, height := GetTerminalSize()
+	if width != 120 || height != 40 {
+		s.logger.Debug("detected terminal size", "width", width, "height", height)
+	}
 	if err := s.tmuxAdapter.ResizeWindow(tmuxSession, width, height); err != nil {
 		// Log warning but don't fail - resize is not critical
 		s.logger.Warn("failed to resize tmux window", "error", err, "session", tmuxSession)
@@ -285,15 +288,6 @@ func GetTerminalSize() (width, height int) {
 	// Try stderr as fallback
 	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
 		width, height = w, h
-	}
-	return
-}
-
-// getTerminalSize returns the current terminal dimensions or defaults
-func (s *tmuxSessionImpl) getTerminalSize() (width, height int) {
-	width, height = GetTerminalSize()
-	if width != 120 || height != 40 {
-		s.logger.Debug("detected terminal size", "width", width, "height", height)
 	}
 	return
 }

--- a/internal/core/terminal/terminal.go
+++ b/internal/core/terminal/terminal.go
@@ -1,0 +1,26 @@
+// Package terminal provides terminal-related utility functions
+package terminal
+
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// GetSize returns the current terminal dimensions or defaults
+func GetSize() (width, height int) {
+	// Default dimensions
+	width, height = 120, 40
+
+	// Try to get terminal size from stdout
+	if w, h, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 && h > 0 {
+		width, height = w, h
+		return
+	}
+
+	// Try stderr as fallback
+	if w, h, err := term.GetSize(os.Stderr.Fd()); err == nil && w > 0 && h > 0 {
+		width, height = w, h
+	}
+	return
+}


### PR DESCRIPTION
## Summary

- Fixes terminal size mismatch when attaching to sessions from different terminals
- Detects current terminal dimensions before attaching
- Resizes tmux window to match current terminal

## Problem

Previously, terminal size was only calculated when starting a session. This caused issues when attaching from a different terminal with different dimensions - the session would retain the original size from creation time, not utilizing the full terminal or appearing too large.

## Solution

1. Added `getTerminalSize()` helper function to detect current terminal dimensions
2. Before attaching, we now:
   - Detect the current terminal size using `term.GetSize()`
   - Create a tmux adapter and call `ResizeWindow()` with the new dimensions
   - Then proceed with normal `tmux attach-session`
3. Errors during resize are handled gracefully (non-critical operation)

## Test Plan

- [x] Build and run tests pass
- [x] Linting passes
- [ ] Manual testing with different terminal sizes

## Related Issues

- Fixes #116
- Related to #105 (which fixed hardcoded terminal size at creation)