### PR TITLE
feat: implement session send-input command

### DIFF
--- a/internal/cli/commands/session/send_input_test.go
+++ b/internal/cli/commands/session/send_input_test.go
@@ -1,0 +1,60 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendInputCmd(t *testing.T) {
+	cmd := sendInputCmd()
+
+	t.Run("command properties", func(t *testing.T) {
+		assert.Equal(t, "send-input", cmd.Use[:10])
+		assert.Contains(t, cmd.Use, "<session-id>")
+		assert.Contains(t, cmd.Use, "<input-text>")
+		assert.Equal(t, []string{"send"}, cmd.Aliases)
+		assert.NotEmpty(t, cmd.Short)
+		assert.NotEmpty(t, cmd.Long)
+		assert.Contains(t, cmd.Long, "Examples:")
+	})
+
+	t.Run("requires exactly 2 arguments", func(t *testing.T) {
+		err := cmd.Args(nil, []string{})
+		assert.Error(t, err)
+
+		err = cmd.Args(nil, []string{"session-id"})
+		assert.Error(t, err)
+
+		err = cmd.Args(nil, []string{"session-id", "input"})
+		assert.NoError(t, err)
+
+		err = cmd.Args(nil, []string{"session-id", "input", "extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has RunE function", func(t *testing.T) {
+		require.NotNil(t, cmd.RunE)
+	})
+}
+
+func TestSendInputToSession(t *testing.T) {
+	// Note: Full integration tests would require mocking the session manager
+	// and session interfaces. For now, we're just testing that the command
+	// is properly constructed and would fail appropriately when run outside
+	// an initialized project.
+
+	t.Run("fails with invalid session", func(t *testing.T) {
+		cmd := sendInputCmd()
+		// Try to send input to a non-existent session
+		err := cmd.RunE(cmd, []string{"non-existent-session", "test input"})
+		assert.Error(t, err)
+		// Could fail either at project root detection or session lookup
+		assert.True(t,
+			strings.Contains(err.Error(), "project root") ||
+				strings.Contains(err.Error(), "session not found"),
+			"Expected error about project root or session not found, got: %v", err)
+	})
+}

--- a/internal/cli/commands/session/session.go
+++ b/internal/cli/commands/session/session.go
@@ -36,6 +36,7 @@ manage their lifecycle.`,
 	cmd.AddCommand(stopCmd())
 	cmd.AddCommand(logsCmd())
 	cmd.AddCommand(removeCmd())
+	cmd.AddCommand(sendInputCmd())
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- Add new `amux session send-input <session> <input>` command
- Enables programmatic input to running agent sessions via stdin
- Follows existing session command patterns

## Changes
- Added `internal/cli/commands/session/send_input.go` with the command implementation
- Added unit tests in `send_input_test.go`
- Integrated command into session command group

## Test plan
- [x] Unit tests pass
- [x] Command structure follows existing patterns
- [ ] Manual testing with actual tmux sessions
- [ ] Integration with AI agent workflows

Closes #97