### PR TITLE
fix: fix test race conditions in workspace tests

### DIFF
--- a/internal/core/session/manager_test.go
+++ b/internal/core/session/manager_test.go
@@ -101,8 +101,14 @@ func TestManager_CreateSessionWithNameAndDescription(t *testing.T) {
 		t.Fatalf("Failed to create session store: %v", err)
 	}
 
-	// Create session manager (nil ID mapper and mailbox manager for tests)
-	manager := NewManager(store, wsManager, nil, nil)
+	// Create ID mapper
+	idMapper, err := idmap.NewIDMapper(configManager.GetAmuxDir())
+	if err != nil {
+		t.Fatalf("Failed to create ID mapper: %v", err)
+	}
+
+	// Create session manager
+	manager := NewManager(store, wsManager, idMapper)
 
 	// Use mock adapter for consistent testing across platforms
 	mockAdapter := tmux.NewMockAdapter()

--- a/internal/core/workspace/manager_test.go
+++ b/internal/core/workspace/manager_test.go
@@ -15,7 +15,9 @@ import (
 func TestManager_CreateWithExistingBranch(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
+	t.Cleanup(func() {
+		os.RemoveAll(repoDir)
+	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -81,7 +83,9 @@ func TestManager_CreateWithExistingBranch(t *testing.T) {
 func TestManager_CreateWithNewBranch(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
+	t.Cleanup(func() {
+		os.RemoveAll(repoDir)
+	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -131,7 +135,9 @@ func TestManager_CreateWithNewBranch(t *testing.T) {
 func TestManager_RemoveWithManuallyDeletedWorktree(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
+	t.Cleanup(func() {
+		os.RemoveAll(repoDir)
+	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -198,7 +204,9 @@ func TestManager_RemoveWithManuallyDeletedWorktree(t *testing.T) {
 func TestManager_ConsistencyChecking(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
+	t.Cleanup(func() {
+		os.RemoveAll(repoDir)
+	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -226,7 +234,11 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create workspace: %v", err)
 		}
-		defer manager.Remove(ws.ID)
+		t.Cleanup(func() {
+			if err := manager.Remove(ws.ID); err != nil {
+				t.Logf("Failed to remove workspace %s: %v", ws.ID, err)
+			}
+		})
 
 		// Get workspace and check consistency
 		retrieved, err := manager.Get(ws.ID)
@@ -261,7 +273,11 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create workspace: %v", err)
 		}
-		defer manager.Remove(ws.ID)
+		t.Cleanup(func() {
+			if err := manager.Remove(ws.ID); err != nil {
+				t.Logf("Failed to remove workspace %s: %v", ws.ID, err)
+			}
+		})
 
 		// Manually delete the folder
 		err = os.RemoveAll(ws.Path)
@@ -388,7 +404,9 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 func TestManager_CreateSetsContextPath(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
+	t.Cleanup(func() {
+		os.RemoveAll(repoDir)
+	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)


### PR DESCRIPTION
## Summary
- Replace `defer` statements with `t.Cleanup()` for proper cleanup order
- Fix race conditions in CI environment where tests were failing intermittently
- Add detailed logging for debugging test failures

## Problem
The `TestWorkspaceCdCommand/WorkspacePathExists` test was failing intermittently in CI with "Workspace path does not exist" error. This was caused by the workspace being removed too early due to improper cleanup order when using `defer`.

## Solution
- Use `t.Cleanup()` instead of `defer` for workspace removal to ensure cleanup happens after all subtests complete
- Use `t.Cleanup()` for temporary directory removal as well
- Add detailed logging to help debug similar issues in the future

## Test plan
- [x] Run tests locally with race detection: `go test -v -race ./internal/cli/commands -run TestWorkspace`
- [x] Run tests multiple times to ensure stability: `go test -v -race ./internal/cli/commands -run TestWorkspace -count=10`
- [ ] Verify CI tests pass consistently