### PR TITLE
fix: add automatic cleanup for test temporary directories (#137)

### DIFF
--- a/internal/cli/commands/session/helpers_test.go
+++ b/internal/cli/commands/session/helpers_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +16,6 @@ import (
 func TestCreateAutoWorkspace(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -48,7 +46,6 @@ func TestCreateAutoWorkspace(t *testing.T) {
 func TestCreateAutoWorkspaceUniqueness(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -79,7 +76,6 @@ func TestCreateAutoWorkspaceUniqueness(t *testing.T) {
 func TestCreateAutoWorkspaceWithCustomNameAndDescription(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -110,7 +106,6 @@ func TestCreateAutoWorkspaceWithCustomNameAndDescription(t *testing.T) {
 func TestCreateAutoWorkspaceWithCustomNameOnly(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)

--- a/internal/cli/commands/session/remove_test.go
+++ b/internal/cli/commands/session/remove_test.go
@@ -26,7 +26,6 @@ func TestRemoveSession(t *testing.T) {
 
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer os.RemoveAll(repoDir)
 
 	// Change to test directory to ensure commands work correctly
 	oldWd, err := os.Getwd()

--- a/internal/cli/commands/workspace_test.go
+++ b/internal/cli/commands/workspace_test.go
@@ -15,9 +15,6 @@ import (
 func TestWorkspaceRemovalSafetyCheck(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -138,9 +135,6 @@ func TestWorkspaceRemovalSafetyCheck(t *testing.T) {
 func TestWorkspaceCdCommand(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)

--- a/internal/core/tail/tail_test.go
+++ b/internal/core/tail/tail_test.go
@@ -3,7 +3,6 @@ package tail_test
 import (
 	"bytes"
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -33,9 +32,6 @@ func (w *writerFunc) Write(p []byte) (int, error) {
 func TestTailer_Follow(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer func() {
-		_ = os.RemoveAll(repoDir)
-	}()
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -195,9 +191,6 @@ func TestTailer_Follow(t *testing.T) {
 func TestFollowFunc(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	defer func() {
-		_ = os.RemoveAll(repoDir)
-	}()
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)

--- a/internal/core/workspace/manager_test.go
+++ b/internal/core/workspace/manager_test.go
@@ -15,9 +15,6 @@ import (
 func TestManager_CreateWithExistingBranch(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -83,9 +80,6 @@ func TestManager_CreateWithExistingBranch(t *testing.T) {
 func TestManager_CreateWithNewBranch(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -135,9 +129,6 @@ func TestManager_CreateWithNewBranch(t *testing.T) {
 func TestManager_RemoveWithManuallyDeletedWorktree(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -204,9 +195,6 @@ func TestManager_RemoveWithManuallyDeletedWorktree(t *testing.T) {
 func TestManager_ConsistencyChecking(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)
@@ -404,9 +392,6 @@ func TestManager_ConsistencyChecking(t *testing.T) {
 func TestManager_CreateSetsContextPath(t *testing.T) {
 	// Create test repository
 	repoDir := helpers.CreateTestRepo(t)
-	t.Cleanup(func() {
-		os.RemoveAll(repoDir)
-	})
 
 	// Initialize Amux
 	configManager := config.NewManager(repoDir)

--- a/internal/tests/helpers/repo.go
+++ b/internal/tests/helpers/repo.go
@@ -43,6 +43,11 @@ func CreateTestRepo(t *testing.T) string {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 
+	// Register cleanup for the temporary directory
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
 	// Initialize git repo with explicit settings
 	cmd := exec.Command("git", "init", "--initial-branch=main")
 	cmd.Dir = tmpDir

--- a/internal/tests/helpers/repo.go
+++ b/internal/tests/helpers/repo.go
@@ -45,7 +45,7 @@ func CreateTestRepo(t *testing.T) string {
 
 	// Register cleanup for the temporary directory
 	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(tmpDir)
 	})
 
 	// Initialize git repo with explicit settings


### PR DESCRIPTION
## Summary

- Added `t.Cleanup()` to the `CreateTestRepo` function to automatically remove temporary directories after tests complete
- Removed redundant `os.RemoveAll` cleanup calls from all test files
- Fixed unused `os` import errors in test files

## Changes

This PR ensures all `amux-test-*` temporary directories are cleaned up automatically after tests complete, preventing accumulation of temporary files on developers' machines.

The fix follows Go's idiomatic approach by registering cleanup in the helper function where the temporary directory is created, rather than requiring each test to handle cleanup manually.

## Test Plan

- [x] Run `just test` to verify all tests pass
- [x] Check `/tmp` directory to confirm no `amux-test-*` directories remain after tests complete
- [x] Verify pre-commit hooks pass

Fixes #137