### PR TITLE
fix: change --root-dir flag to --git-root in mcp command

### DIFF
--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -10,7 +10,7 @@ Copy this to CLAUDE.local.md and customize it for your workflow.
   "mcpServers": {
     "amux": {
       "command": "/path/to/your/amux/bin/amux",
-      "args": ["mcp", "--root-dir", "/path/to/your/project"],
+      "args": ["mcp", "--git-root", "/path/to/your/project"],
       "env": {}
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ return fmt.Errorf("Workspace not found.")  // Bad
 
 ## Important Notes
 
-1. **MCP Connection**: Always use `--root-dir` flag when starting MCP server
+1. **MCP Connection**: Always use `--git-root` flag when starting MCP server
 2. **Workspace Names**: Use descriptive names with prefixes (fix-, feat-, chore-)
 3. **IDs**: Both names and numeric IDs work for all commands
 4. **Git Integration**: Each workspace is a real git worktree - use git normally
@@ -151,7 +151,7 @@ amux ws show <id-or-name>
 amux ws remove <id-or-name>
 
 # Start MCP server
-amux mcp --root-dir /path/to/project
+amux mcp --git-root /path/to/project
 
 # Check version
 amux version
@@ -181,7 +181,7 @@ For example:
 
 If Claude Code can't connect:
 
-1. Ensure `--root-dir` points to valid git repository
+1. Ensure `--git-root` points to valid git repository
 2. Check amux binary path is absolute in MCP config
 3. Restart Claude Code after config changes
 

--- a/internal/cli/commands/mcp.go
+++ b/internal/cli/commands/mcp.go
@@ -42,11 +42,11 @@ var (
 
 	serveAuthPass string
 
-	rootDir string
+	gitRoot string
 )
 
 func init() {
-	mcpCmd.Flags().StringVar(&rootDir, "root-dir", "", "Project root directory (required if not in amux project)")
+	mcpCmd.Flags().StringVar(&gitRoot, "git-root", "", "Git repository root directory (required if not in amux project)")
 
 	mcpCmd.Flags().StringVarP(&serveTransport, "transport", "t", "", "Transport type (stdio, http, https)")
 
@@ -66,9 +66,9 @@ func runMCP(cmd *cobra.Command, args []string) error {
 	var projectRoot string
 	var err error
 
-	if rootDir != "" {
-		// Use explicitly provided root directory
-		absPath, err := filepath.Abs(rootDir)
+	if gitRoot != "" {
+		// Use explicitly provided git root directory
+		absPath, err := filepath.Abs(gitRoot)
 		if err != nil {
 			return fmt.Errorf("invalid root directory: %w", err)
 		}
@@ -77,13 +77,13 @@ func runMCP(cmd *cobra.Command, args []string) error {
 		// Validate it's a git repository
 		gitOps := git.NewOperations(projectRoot)
 		if !gitOps.IsGitRepository() {
-			return fmt.Errorf("--root-dir must be a git repository: %s", projectRoot)
+			return fmt.Errorf("--git-root must be a git repository: %s", projectRoot)
 		}
 	} else {
 		// Try to find project root from current directory
 		projectRoot, err = config.FindProjectRoot()
 		if err != nil {
-			return fmt.Errorf("not in an amux project and --root-dir not specified")
+			return fmt.Errorf("not in an amux project and --git-root not specified")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Changed `--root-dir` flag to `--git-root` to make it clear that a Git repository root is required
- Updated all references in code and documentation

## Motivation

The `--root-dir` parameter name was ambiguous and didn't clearly indicate that it requires a Git repository root directory. The new `--git-root` name makes this requirement explicit and improves user experience.

## Changes

- Renamed flag from `--root-dir` to `--git-root` in `internal/cli/commands/mcp.go`
- Updated error messages to reference `--git-root`
- Updated documentation in `CLAUDE.md` and `CLAUDE.local.md.example`

## Test Plan

- [x] All tests pass (`just test`)
- [x] Linting passes (`just check`)
- [ ] Manual testing of `amux mcp --git-root /path/to/repo`