### PR TITLE
refactor: remove unused repository and defaultAgent fields from project config

### DIFF
--- a/internal/cli/commands/config_show.go
+++ b/internal/cli/commands/config_show.go
@@ -64,8 +64,6 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 func showConfigPretty(cfg *config.Config) error {
 	ui.OutputLine("Project Configuration:")
 	ui.OutputLine("  Name: %s", cfg.Project.Name)
-	ui.OutputLine("  Repository: %s", cfg.Project.Repository)
-	ui.OutputLine("  Default Agent: %s", cfg.Project.DefaultAgent)
 
 	ui.OutputLine("\nMCP Configuration:")
 	ui.OutputLine("  Transport: %s", cfg.MCP.Transport.Type)

--- a/internal/cli/commands/config_test.go
+++ b/internal/cli/commands/config_test.go
@@ -20,9 +20,7 @@ func TestConfigShowCommand(t *testing.T) {
 	testCfg := &config.Config{
 		Version: "1.0",
 		Project: config.ProjectConfig{
-			Name:         "test-project",
-			Repository:   "https://github.com/test/project.git",
-			DefaultAgent: "test-agent",
+			Name: "test-project",
 		},
 		MCP: config.MCPConfig{
 			Transport: config.TransportConfig{

--- a/internal/cli/commands/config_validate.go
+++ b/internal/cli/commands/config_validate.go
@@ -71,14 +71,6 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 		ui.Info("  Version: %s", cfg.Version)
 		ui.Info("  Project: %s", cfg.Project.Name)
 
-		if cfg.Project.Repository != "" {
-			ui.Info("  Repository: %s", cfg.Project.Repository)
-		}
-
-		if cfg.Project.DefaultAgent != "" {
-			ui.Info("  Default Agent: %s", cfg.Project.DefaultAgent)
-		}
-
 		ui.Info("")
 		ui.Info("MCP Configuration:")
 		ui.Info("  Transport: %s", cfg.MCP.Transport.Type)

--- a/internal/cli/commands/config_validate_test.go
+++ b/internal/cli/commands/config_validate_test.go
@@ -32,8 +32,6 @@ func TestConfigValidateCommand(t *testing.T) {
 			config: `version: "1.0"
 project:
   name: test-project
-  repository: https://github.com/test/project.git
-  defaultAgent: claude
 mcp:
   transport:
     type: stdio
@@ -168,8 +166,6 @@ func TestConfigValidateCommandVerbose(t *testing.T) {
 	validConfig := `version: "1.0"
 project:
   name: test-project
-  repository: https://github.com/test/project.git
-  defaultAgent: claude
 mcp:
   transport:
     type: stdio
@@ -222,8 +218,6 @@ agents:
 	assert.Contains(t, output, "Configuration details:")
 	assert.Contains(t, output, "Version: 1.0")
 	assert.Contains(t, output, "Project: test-project")
-	assert.Contains(t, output, "Repository: https://github.com/test/project.git")
-	assert.Contains(t, output, "Default Agent: claude")
 	assert.Contains(t, output, "MCP Configuration:")
 	assert.Contains(t, output, "Transport: stdio")
 	assert.Contains(t, output, "Agents (2 configured):")

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -38,12 +38,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not a git repository. Amux requires a git repository")
 	}
 
-	// Get repository info
-	repoInfo, err := gitOps.GetRepositoryInfo()
-	if err != nil {
-		return fmt.Errorf("failed to get repository info: %w", err)
-	}
-
 	// Create configuration manager
 	configManager := config.NewManager(cwd)
 
@@ -57,7 +51,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Set project name from directory
 	cfg.Project.Name = filepath.Base(cwd)
-	cfg.Project.Repository = repoInfo.RemoteURL
 
 	// Save configuration
 	if err := configManager.Save(cfg); err != nil {

--- a/internal/core/agent/manager_test.go
+++ b/internal/core/agent/manager_test.go
@@ -19,8 +19,7 @@ func setupTestManager(t *testing.T) (*Manager, string) {
 	testConfig := &config.Config{
 		Version: "1.0",
 		Project: config.ProjectConfig{
-			Name:         "test-project",
-			DefaultAgent: "claude",
+			Name: "test-project",
 		},
 		MCP: config.MCPConfig{
 			Transport: config.TransportConfig{

--- a/internal/core/config/schema_validation_test.go
+++ b/internal/core/config/schema_validation_test.go
@@ -21,8 +21,6 @@ func TestValidateYAML(t *testing.T) {
 			yaml: `version: "1.0"
 project:
   name: test-project
-  repository: https://github.com/test/project.git
-  defaultAgent: claude
 mcp:
   transport:
     type: stdio
@@ -199,8 +197,6 @@ agents:
 			yaml: `version: "1.0"
 project:
   name: test-project
-  repository: https://github.com/test/project.git
-  defaultAgent: claude
 mcp:
   transport:
     type: http
@@ -253,7 +249,6 @@ func TestLoadWithValidation(t *testing.T) {
 		validConfig := `version: "1.0"
 project:
   name: test-project
-  repository: https://github.com/test/project.git
 agents:
   claude:
     name: Claude

--- a/internal/core/config/schemas/config.schema.json
+++ b/internal/core/config/schemas/config.schema.json
@@ -22,15 +22,6 @@
           "type": "string",
           "description": "Project name",
           "minLength": 1
-        },
-        "repository": {
-          "type": "string",
-          "description": "Git repository URL",
-          "format": "uri"
-        },
-        "defaultAgent": {
-          "type": "string",
-          "description": "Default agent ID to use when not specified"
         }
       }
     },

--- a/internal/core/config/types.go
+++ b/internal/core/config/types.go
@@ -16,9 +16,7 @@ type Config struct {
 
 // ProjectConfig represents project-specific configuration
 type ProjectConfig struct {
-	Name         string `yaml:"name"`
-	Repository   string `yaml:"repository"`
-	DefaultAgent string `yaml:"defaultAgent"`
+	Name string `yaml:"name"`
 }
 
 // MCPConfig represents MCP server configuration
@@ -158,9 +156,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Version: "1.0",
 		Project: ProjectConfig{
-			Name:         "amux-project",
-			Repository:   "",
-			DefaultAgent: "claude",
+			Name: "amux-project",
 		},
 		MCP: MCPConfig{
 			Transport: TransportConfig{


### PR DESCRIPTION
## Summary

- Removed unused `repository` and `defaultAgent` fields from ProjectConfig
- These fields were not being used anywhere in the codebase
- Simplifies configuration and reduces complexity

## Changes

- Updated `ProjectConfig` struct to only contain `Name` field
- Updated JSON schema to remove the unused fields
- Cleaned up all test references
- Simplified `amux init` command by removing repository URL retrieval

## Test Plan

- [x] Run `just test` to ensure all tests pass
- [x] Run `just check` for linting and formatting
- [ ] Test `amux init` command works correctly
- [ ] Verify existing configurations still work (backward compatibility)