### PR TITLE
fix: disable workspace-browse MCP tool for v0.1.0

### DIFF
--- a/internal/mcp/workspace_bridge_tools.go
+++ b/internal/mcp/workspace_bridge_tools.go
@@ -37,14 +37,16 @@ func (s *ServerV2) registerWorkspaceBridgeTools() error {
 	s.mcpServer.AddTool(mcp.NewTool("resource_workspace_show", showOpts...), s.handleResourceWorkspaceShow)
 
 	// resource_workspace_browse - Bridge to amux://workspace/{id}/files
-	browseOpts, err := WithStructOptions(
-		GetEnhancedDescription("resource_workspace_browse"),
-		WorkspaceBrowseParams{},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create resource_workspace_browse options: %w", err)
-	}
-	s.mcpServer.AddTool(mcp.NewTool("resource_workspace_browse", browseOpts...), s.handleResourceWorkspaceBrowse)
+	// Disabled for v0.1.0: AI agents overuse it, low value for own workspace, error-prone
+	// See https://github.com/choplin/amux/issues/164 for context and re-enablement considerations
+	// browseOpts, err := WithStructOptions(
+	// 	GetEnhancedDescription("resource_workspace_browse"),
+	// 	WorkspaceBrowseParams{},
+	// )
+	// if err != nil {
+	// 	return fmt.Errorf("failed to create resource_workspace_browse options: %w", err)
+	// }
+	// s.mcpServer.AddTool(mcp.NewTool("resource_workspace_browse", browseOpts...), s.handleResourceWorkspaceBrowse)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Temporarily disable the `resource_workspace_browse` MCP tool for v0.1.0 release
- Addresses issues with AI agent overuse and reliability problems
- The underlying resource handler remains intact for future re-enablement

## Context

The `resource_workspace_browse` tool has been causing issues in practice:

1. **AI Agent Overuse**: AI agents tend to use this tool excessively, consuming unnecessary context and tokens
2. **Low Value for Own Workspace**: When agents work in their own workspace, browsing provides little value as they already know what they're working on  
3. **Error-Prone**: The tool often returns errors, affecting reliability

## Changes

- Commented out the tool registration in `internal/mcp/workspace_bridge_tools.go`
- Added detailed comment with issue reference for future context
- All other MCP tools remain functional

## Related

- Issue: #164 - Contains full context and re-enablement considerations

## Test Plan

- [x] Build passes
- [x] All tests pass
- [x] Other MCP tools continue to work as expected