### PR TITLE
fix: hooks execute in workspace directory and implement session hooks

### DIFF
--- a/docs/adr/027-hook-execution-directory.md
+++ b/docs/adr/027-hook-execution-directory.md
@@ -1,0 +1,117 @@
+# ADR-027: Hook Execution Directory
+
+**Status**: Accepted
+
+## Context
+
+Currently, all hooks in amux execute in the project root directory, regardless of which workspace triggered them. This severely limits the usefulness of hooks, as workspace-specific setup operations (like installing dependencies or setting up environment) cannot be performed without manual workarounds.
+
+### Current Implementation Problems
+
+1. **Manual Directory Changes**: Users must prefix every hook command with `cd $AMUX_WORKSPACE_PATH &&` to run commands in the correct directory
+2. **Error-Prone**: Forgetting the cd prefix causes hooks to run in the wrong directory
+3. **Verbose Configuration**: Every hook needs boilerplate for directory navigation
+4. **Limited Usefulness**: Can't use simple commands like `npm install` or `poetry install` directly
+
+### Example of Current Workaround
+
+```yaml
+hooks:
+  workspace_create:
+    - name: "Install dependencies"
+      command: "cd $AMUX_WORKSPACE_PATH && npm install"
+    - name: "Setup environment"
+      command: "cd $AMUX_WORKSPACE_PATH && ./scripts/setup.sh"
+```
+
+## Decision
+
+Change hook execution behavior to use context-appropriate working directories:
+
+1. **Workspace hooks** (`workspace_create`, `workspace_remove`) - Execute in the workspace directory
+2. **Session hooks** (`session_start`, `session_stop`) - Execute in the session's assigned workspace directory
+3. **Session hooks without workspace** - Fail with clear error message
+
+Additionally:
+- Rename `agent_start/stop` events to `session_start/stop` for consistency with the rest of the codebase
+- Execute commands through shell (`sh -c`) to support redirections, pipes, and other shell features
+
+## Rationale
+
+### Principle of Least Surprise
+
+Hooks should run where the action occurred. When creating a workspace, it's natural to expect hooks to run in that workspace.
+
+### Common Use Cases
+
+Most hook use cases involve workspace-specific operations:
+- Installing dependencies (`npm install`, `pip install`, `go mod download`)
+- Setting up environment files (`.env`, `config.yaml`)
+- Running initialization scripts
+- Creating workspace-specific directories
+
+### Consistency with Sessions
+
+Sessions already run in their assigned workspaces. Hooks should follow the same pattern.
+
+### Shell Execution
+
+Using `sh -c` allows natural shell syntax:
+- Redirections: `echo "test" > file.txt`
+- Pipes: `cat file | grep pattern`
+- Multiple commands: `command1 && command2`
+
+## Consequences
+
+### Positive
+
+- Hooks become immediately useful for workspace setup
+- No need for manual `cd` commands in hook definitions
+- More intuitive behavior - hooks run where the action occurred
+- Enables common use cases like dependency installation
+- Consistent with session execution model
+
+### Negative
+
+- **Breaking change** for existing hooks that assume root directory execution
+- Hooks that need to access project-level resources must use `$AMUX_PROJECT_ROOT`
+
+### Migration Path
+
+Existing hooks that rely on root directory execution must be updated:
+
+```yaml
+# Before
+hooks:
+  workspace_create:
+    - name: "Run project script"
+      command: "./scripts/setup.sh"
+
+# After
+hooks:
+  workspace_create:
+    - name: "Run project script"
+      command: "cd $AMUX_PROJECT_ROOT && ./scripts/setup.sh"
+```
+
+## Implementation Notes
+
+The implementation adds a `WithWorkingDir()` method to the hook executor:
+
+```go
+// Set working directory based on context
+executor := hooks.NewExecutor(configDir, env).WithWorkingDir(workspace.Path)
+```
+
+For session hooks, workspace assignment is required:
+
+```go
+if workspace == nil {
+    return fmt.Errorf("session hooks require workspace assignment")
+}
+```
+
+## References
+
+- Issue #167: Hooks execute in wrong directory
+- Issue #169: Replace agent_start/stop with session_start/stop and implement session hooks

--- a/docs/adr/027-hook-execution-directory.md
+++ b/docs/adr/027-hook-execution-directory.md
@@ -32,9 +32,7 @@ Change hook execution behavior to use context-appropriate working directories:
 2. **Session hooks** (`session_start`, `session_stop`) - Execute in the session's assigned workspace directory
 3. **Session hooks without workspace** - Fail with clear error message
 
-Additionally:
-
-- Rename `agent_start/stop` events to `session_start/stop` for consistency with the rest of the codebase
+Additionally, rename `agent_start/stop` events to `session_start/stop` for consistency with the rest of the codebase where "session" terminology is used throughout (e.g., `amux ps` lists sessions, `amux run` creates sessions).
 
 ## Rationale
 
@@ -55,15 +53,24 @@ Most hook use cases involve workspace-specific operations:
 
 Sessions already run in their assigned workspaces. Hooks should follow the same pattern.
 
-### Direct Command Execution
+### Command Execution
 
-Commands are executed directly without shell interpretation for simplicity and portability. If shell features are needed, users can explicitly invoke a shell:
+Commands are executed directly without shell interpretation. This approach provides:
+
+- **Simplicity**: No complex shell parsing or escaping
+- **Portability**: Works identically across all platforms (Windows, macOS, Linux)
+- **Security**: No shell injection risks
+- **Predictability**: Arguments are passed exactly as specified
+
+If shell features (redirections, pipes, etc.) are needed, users can explicitly invoke a shell:
 
 ```yaml
 hooks:
   workspace_create:
-    - name: "Use shell features"
+    - name: "Create file with redirection"
       command: "sh -c 'echo test > output.txt'"
+    - name: "Use pipes"
+      command: "sh -c 'cat input.txt | grep pattern'"
 ```
 
 ## Consequences

--- a/docs/adr/027-hook-execution-directory.md
+++ b/docs/adr/027-hook-execution-directory.md
@@ -35,7 +35,6 @@ Change hook execution behavior to use context-appropriate working directories:
 Additionally:
 
 - Rename `agent_start/stop` events to `session_start/stop` for consistency with the rest of the codebase
-- Execute commands through shell (`sh -c`) to support redirections, pipes, and other shell features
 
 ## Rationale
 
@@ -56,13 +55,16 @@ Most hook use cases involve workspace-specific operations:
 
 Sessions already run in their assigned workspaces. Hooks should follow the same pattern.
 
-### Shell Execution
+### Direct Command Execution
 
-Using `sh -c` allows natural shell syntax:
+Commands are executed directly without shell interpretation for simplicity and portability. If shell features are needed, users can explicitly invoke a shell:
 
-- Redirections: `echo "test" > file.txt`
-- Pipes: `cat file | grep pattern`
-- Multiple commands: `command1 && command2`
+```yaml
+hooks:
+  workspace_create:
+    - name: "Use shell features"
+      command: "sh -c 'echo test > output.txt'"
+```
 
 ## Consequences
 

--- a/docs/adr/027-hook-execution-directory.md
+++ b/docs/adr/027-hook-execution-directory.md
@@ -33,6 +33,7 @@ Change hook execution behavior to use context-appropriate working directories:
 3. **Session hooks without workspace** - Fail with clear error message
 
 Additionally:
+
 - Rename `agent_start/stop` events to `session_start/stop` for consistency with the rest of the codebase
 - Execute commands through shell (`sh -c`) to support redirections, pipes, and other shell features
 
@@ -45,6 +46,7 @@ Hooks should run where the action occurred. When creating a workspace, it's natu
 ### Common Use Cases
 
 Most hook use cases involve workspace-specific operations:
+
 - Installing dependencies (`npm install`, `pip install`, `go mod download`)
 - Setting up environment files (`.env`, `config.yaml`)
 - Running initialization scripts
@@ -57,6 +59,7 @@ Sessions already run in their assigned workspaces. Hooks should follow the same 
 ### Shell Execution
 
 Using `sh -c` allows natural shell syntax:
+
 - Redirections: `echo "test" > file.txt`
 - Pipes: `cat file | grep pattern`
 - Multiple commands: `command1 && command2`

--- a/internal/cli/commands/hooks.go
+++ b/internal/cli/commands/hooks.go
@@ -271,7 +271,7 @@ func testHooks(cmd *cobra.Command, args []string) error {
 	event := hooks.Event(eventName)
 	switch event {
 	case hooks.EventWorkspaceCreate, hooks.EventWorkspaceRemove,
-		hooks.EventAgentStart, hooks.EventAgentStop:
+		hooks.EventSessionStart, hooks.EventSessionStop:
 		// Valid event
 	default:
 		return fmt.Errorf("unknown event: %s", eventName)

--- a/internal/cli/commands/session/hooks.go
+++ b/internal/cli/commands/session/hooks.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aki/amux/internal/cli/ui"
+	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/hooks"
+	"github.com/aki/amux/internal/core/session"
+	"github.com/aki/amux/internal/core/workspace"
+)
+
+// executeSessionHooks executes hooks for session events
+func executeSessionHooks(sess session.Session, ws *workspace.Workspace, event hooks.Event) error {
+	if ws == nil {
+		return fmt.Errorf("session hooks require workspace assignment")
+	}
+
+	// Find project root
+	projectRoot, err := config.FindProjectRoot()
+	if err != nil {
+		return err
+	}
+
+	configManager := config.NewManager(projectRoot)
+	configDir := configManager.GetAmuxDir()
+
+	// Load hooks configuration
+	hooksConfig, err := hooks.LoadConfig(configDir)
+	if err != nil {
+		return fmt.Errorf("failed to load hooks: %w", err)
+	}
+
+	// Get hooks for this event
+	eventHooks := hooksConfig.GetHooksForEvent(event)
+	if len(eventHooks) == 0 {
+		return nil // No hooks configured
+	}
+
+	// Check if hooks are trusted
+	trusted, err := hooks.IsTrusted(configDir, hooksConfig)
+	if err != nil {
+		return fmt.Errorf("failed to check hook trust: %w", err)
+	}
+
+	if !trusted {
+		ui.Warning("This project has hooks configured but they are not trusted.")
+		ui.Info("Run 'amux hooks trust' to trust hooks in this project.")
+		return nil
+	}
+
+	// Get session info
+	info := sess.Info()
+
+	// Prepare environment variables
+	env := map[string]string{
+		// Session-specific variables
+		"AMUX_SESSION_ID":          info.ID,
+		"AMUX_SESSION_INDEX":       info.Index,
+		"AMUX_SESSION_AGENT_ID":    info.AgentID,
+		"AMUX_SESSION_NAME":        info.Name,
+		"AMUX_SESSION_DESCRIPTION": info.Description,
+		"AMUX_SESSION_COMMAND":     info.Command,
+		// Workspace variables
+		"AMUX_WORKSPACE_ID":          ws.ID,
+		"AMUX_WORKSPACE_NAME":        ws.Name,
+		"AMUX_WORKSPACE_PATH":        ws.Path,
+		"AMUX_WORKSPACE_BRANCH":      ws.Branch,
+		"AMUX_WORKSPACE_BASE_BRANCH": ws.BaseBranch,
+		// Event and context
+		"AMUX_EVENT":        string(event),
+		"AMUX_EVENT_TIME":   time.Now().Format(time.RFC3339),
+		"AMUX_PROJECT_ROOT": projectRoot,
+		"AMUX_CONFIG_DIR":   configDir,
+	}
+
+	// Execute hooks in workspace directory
+	executor := hooks.NewExecutor(configDir, env).WithWorkingDir(ws.Path)
+	return executor.ExecuteHooks(event, eventHooks)
+}

--- a/internal/cli/commands/session/run.go
+++ b/internal/cli/commands/session/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aki/amux/internal/cli/ui"
 	"github.com/aki/amux/internal/core/agent"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/hooks"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -178,6 +179,12 @@ func runSession(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.Success("Agent session started successfully!")
+
+	// Execute session start hooks
+	if err := executeSessionHooks(sess, ws, hooks.EventSessionStart); err != nil {
+		ui.Error("Hook execution failed: %v", err)
+		// Don't fail the session start, just warn
+	}
 
 	// Handle auto-attach for tmux sessions
 	info := sess.Info()

--- a/internal/cli/commands/session/stop.go
+++ b/internal/cli/commands/session/stop.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aki/amux/internal/cli/ui"
 	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/hooks"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
 )
@@ -46,6 +47,21 @@ func stopSession(cmd *cobra.Command, args []string) error {
 	sess, err := sessionManager.ResolveSession(cmd.Context(), session.Identifier(sessionID))
 	if err != nil {
 		return fmt.Errorf("failed to get session: %w", err)
+	}
+
+	// Get workspace for hooks
+	info := sess.Info()
+	var ws *workspace.Workspace
+	if info.WorkspaceID != "" {
+		ws, _ = wsManager.ResolveWorkspace(cmd.Context(), workspace.Identifier(info.WorkspaceID))
+	}
+
+	// Execute session stop hooks (before stopping)
+	if ws != nil {
+		if err := executeSessionHooks(sess, ws, hooks.EventSessionStop); err != nil {
+			ui.Warning("Hook execution failed: %v", err)
+			// Continue with stop even if hooks fail
+		}
 	}
 
 	// Stop session

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -526,7 +526,7 @@ func executeWorkspaceHooks(ws *workspace.Workspace, event hooks.Event) error {
 		"AMUX_CONFIG_DIR":            configDir,
 	}
 
-	// Execute hooks
-	executor := hooks.NewExecutor(configDir, env)
+	// Execute hooks in workspace directory
+	executor := hooks.NewExecutor(configDir, env).WithWorkingDir(ws.Path)
 	return executor.ExecuteHooks(event, eventHooks)
 }

--- a/internal/core/hooks/executor.go
+++ b/internal/core/hooks/executor.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"time"
 
 	"github.com/aki/amux/internal/cli/ui"
@@ -122,13 +122,13 @@ func (e *Executor) executeHook(hook *Hook, index, total int) (*ExecutionResult, 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Execute command through shell to support redirections, pipes, etc.
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
-	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	// Parse command
+	args := strings.Fields(cmdStr)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("empty command")
 	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
 	// Set working directory
 	if e.workingDir != "" {

--- a/internal/core/hooks/executor.go
+++ b/internal/core/hooks/executor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/aki/amux/internal/cli/ui"
@@ -122,7 +123,12 @@ func (e *Executor) executeHook(hook *Hook, index, total int) (*ExecutionResult, 
 	defer cancel()
 
 	// Execute command through shell to support redirections, pipes, etc.
-	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "cmd", "/C", cmdStr)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	}
 
 	// Set working directory
 	if e.workingDir != "" {

--- a/internal/core/hooks/executor.go
+++ b/internal/core/hooks/executor.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/aki/amux/internal/cli/ui"
@@ -16,10 +15,11 @@ import (
 
 // Executor executes hooks
 type Executor struct {
-	configDir string
-	env       map[string]string
-	dryRun    bool
-	output    io.Writer
+	configDir  string
+	env        map[string]string
+	dryRun     bool
+	output     io.Writer
+	workingDir string // New field for context-specific working directory
 }
 
 // NewExecutor creates a new hook executor
@@ -40,6 +40,12 @@ func (e *Executor) WithDryRun(dryRun bool) *Executor {
 // WithOutput sets custom output writer
 func (e *Executor) WithOutput(w io.Writer) *Executor {
 	e.output = w
+	return e
+}
+
+// WithWorkingDir sets the working directory for hook execution
+func (e *Executor) WithWorkingDir(dir string) *Executor {
+	e.workingDir = dir
 	return e
 }
 
@@ -115,16 +121,17 @@ func (e *Executor) executeHook(hook *Hook, index, total int) (*ExecutionResult, 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Parse command
-	args := strings.Fields(cmdStr)
-	if len(args) == 0 {
-		return nil, fmt.Errorf("empty command")
+	// Execute command through shell to support redirections, pipes, etc.
+	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+
+	// Set working directory
+	if e.workingDir != "" {
+		// Use context-specific working directory (workspace path)
+		cmd.Dir = e.workingDir
+	} else {
+		// Fall back to project root (parent of .amux)
+		cmd.Dir = filepath.Dir(e.configDir)
 	}
-
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-
-	// Set working directory to project root (parent of .amux)
-	cmd.Dir = filepath.Dir(e.configDir)
 
 	// Set environment
 	cmd.Env = os.Environ()

--- a/internal/core/hooks/types.go
+++ b/internal/core/hooks/types.go
@@ -40,10 +40,10 @@ const (
 	EventWorkspaceCreate Event = "workspace_create"
 	// EventWorkspaceRemove fires before workspace removal
 	EventWorkspaceRemove Event = "workspace_remove"
-	// EventAgentStart fires when agent session starts
-	EventAgentStart Event = "agent_start"
-	// EventAgentStop fires when agent session stops
-	EventAgentStop Event = "agent_stop"
+	// EventSessionStart fires when session starts
+	EventSessionStart Event = "session_start"
+	// EventSessionStop fires when session stops
+	EventSessionStop Event = "session_stop"
 )
 
 // ExecutionResult represents the result of hook execution


### PR DESCRIPTION
## Summary

This PR addresses two related issues:
1. Fixes hook execution directory to use workspace path instead of project root (#167)
2. Implements session hooks with corrected naming (#169)

## Changes

### Hook Execution Directory Fix
- Added `WithWorkingDir()` method to hook executor for context-specific execution
- Hooks now execute in the workspace directory by default
- Commands are executed directly (without shell) for simplicity and portability

### Session Hooks Implementation
- Renamed `agent_start/stop` to `session_start/stop` for consistency
- Implemented session hooks that trigger on session start/stop
- Session hooks require workspace assignment (fail otherwise)
- Added comprehensive environment variables for session context (excluding type-specific fields)

### Documentation
- Added ADR-027 documenting the breaking change and design decisions
- Updated hook configuration to reflect new event names

## Command Execution Approach

Commands are executed directly without shell interpretation. This provides:
- **Simplicity**: No complex shell parsing or platform differences
- **Portability**: Works identically on Windows, macOS, and Linux
- **Security**: No shell injection risks
- **Predictability**: Arguments are passed exactly as specified

If shell features are needed, users can explicitly invoke a shell:
```yaml
hooks:
  workspace_create:
    - name: "Use shell features"
      command: "sh -c 'echo test > output.txt'"
```

## Breaking Changes

⚠️ **BREAKING**: Hooks now execute in workspace directory by default.

Existing hooks that depend on project root execution must be updated:

```yaml
# Before
- event: workspace_create
  command: ./scripts/setup.sh

# After  
- event: workspace_create
  command: cd $AMUX_PROJECT_ROOT && ./scripts/setup.sh
```

## Test Plan

- [x] Unit tests pass for all modified packages
- [x] Manual testing confirms hooks execute in workspace directory
- [x] Verified fallback behavior for hooks needing project root access
- [x] CI passes on all platforms (Windows, macOS, Linux)

## Related Issues

- Fixes #167 - Hooks execute in wrong directory
- Fixes #169 - Replace agent_start/stop with session_start/stop