### PR TITLE
fix: update release workflow to create tar.gz archives for Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,25 +25,31 @@ jobs:
         run: just test
       - name: Create release binaries
         run: |
-          # Build for multiple platforms using just
+          # Create output directory
+          mkdir -p dist
+
+          # Extract version from tag
+          VERSION=${GITHUB_REF#refs/tags/v}
+
+          # Build for multiple platforms and create tar.gz archives
           GOOS=linux GOARCH=amd64 just build
-          mv bin/amux bin/amux-linux-amd64
+          tar -czf dist/amux_${VERSION}_linux_amd64.tar.gz -C bin amux
 
           GOOS=linux GOARCH=arm64 just build
-          mv bin/amux bin/amux-linux-arm64
+          tar -czf dist/amux_${VERSION}_linux_arm64.tar.gz -C bin amux
 
           GOOS=darwin GOARCH=amd64 just build
-          mv bin/amux bin/amux-darwin-amd64
+          tar -czf dist/amux_${VERSION}_darwin_amd64.tar.gz -C bin amux
 
           GOOS=darwin GOARCH=arm64 just build
-          mv bin/amux bin/amux-darwin-arm64
+          tar -czf dist/amux_${VERSION}_darwin_arm64.tar.gz -C bin amux
 
           GOOS=windows GOARCH=amd64 just build
-          mv bin/amux bin/amux-windows-amd64.exe
+          tar -czf dist/amux_${VERSION}_windows_amd64.tar.gz -C bin amux.exe
 
-          # Create checksums
-          cd bin
-          sha256sum amux-* > checksums.txt
+          # Create checksums with the expected filename
+          cd dist
+          sha256sum *.tar.gz > amux_${VERSION}_checksums.txt
           cd ..
       - name: Create changelog
         id: changelog
@@ -70,8 +76,8 @@ jobs:
         with:
           body_path: CHANGELOG_CURRENT.md
           files: |
-            bin/amux-*
-            bin/checksums.txt
+            dist/*.tar.gz
+            dist/amux_*_checksums.txt
           draft: ${{ github.ref == 'refs/heads/main' }}
           prerelease: ${{ contains(github.ref, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Fix the release workflow to create tar.gz archives that the Homebrew tap update CI expects.

## Problem

The current release workflow creates raw binary files, but the Homebrew tap update CI expects:
- Files in tar.gz format: `amux_VERSION_PLATFORM.tar.gz`
- Checksums file named: `amux_VERSION_checksums.txt`

This mismatch causes the Homebrew formula to have empty SHA256 values.

## Changes

- Modified release workflow to create tar.gz archives for all platforms
- Use correct filename format expected by Homebrew CI
- Generate checksums file with the expected name

## Test Plan

After this PR is merged, the next release will:
1. Create tar.gz archives instead of raw binaries
2. Generate checksums with the correct filename
3. Trigger the Homebrew tap update CI successfully
4. Result in a working Homebrew formula with proper SHA256 values