### PR TITLE
fix: remove manual binary renaming in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
       - name: Install just
         uses: extractions/setup-just@v3
       - name: Cache Go modules
@@ -44,8 +44,6 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           just build
-          # Rename for platform-specific artifact
-          mv bin/amux amux${{ matrix.os == 'windows-latest' && '.exe' || '' }}
       - name: Test binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |


### PR DESCRIPTION
Now that justfile handles Windows .exe extension properly (fixed in d85c624), we don't need to manually rename the binary in the build workflow anymore.

This removes the unnecessary  command that was trying to rename the binary for Windows builds.