### PR TITLE
fix: update binary paths in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,15 +47,15 @@ jobs:
       - name: Test binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          ./amux version || true
-          ./amux --help
+          ./bin/amux version || true
+          ./bin/amux --help
       - name: Test binary (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          .\amux.exe version
-          .\amux.exe --help
+          .\bin\amux.exe version
+          .\bin\amux.exe --help
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: amux-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: amux${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          path: bin/amux${{ matrix.os == 'windows-latest' && '.exe' || '' }}


### PR DESCRIPTION
The justfile now outputs binaries to the bin/ directory, so we need to update the test and upload paths in the build workflow accordingly.

This fixes the build failures introduced in #179.