### PR TITLE
fix: standardize CLI output design

### DIFF
--- a/docs/cli-output-guidelines.md
+++ b/docs/cli-output-guidelines.md
@@ -60,11 +60,11 @@ This document establishes the design principles and patterns for consistent CLI 
 #### Color Palette
 
 - **Default**: Terminal default (no color)
-- **Success**: Green (#00D26A) - Sparingly, for final results
-- **Error**: Red (#F85149) - Only for actual errors
-- **Warning**: Yellow (#F0AD4E) - Only for important warnings
-- **Info**: Blue (#0969DA) - Rarely needed
-- **Dim**: Gray (#6E7781) - For metadata
+- **Success**: Green (#00FF00) - Sparingly, for final results
+- **Error**: Red (#FF0000) - Only for actual errors
+- **Warning**: Yellow (#FFAA00) - Only for important warnings
+- **Info**: Blue (#0099FF) - Rarely needed
+- **Dim**: Gray (#888888) - For metadata
 
 #### Color Usage Rules
 
@@ -92,17 +92,18 @@ This document establishes the design principles and patterns for consistent CLI 
 ### Success Messages
 
 ```text
-✅ {Action} completed successfully
+{Action message or confirmation}
 
 {Optional details without icons}
 ```
 
+Note: The ✅ icon should be used sparingly, only for final completion of major operations.
+
 Example:
 
 ```text
-✅ Workspace created successfully
+Created workspace 'fix-auth-bug'
 
-Name:   fix-auth-bug
 ID:     3
 Branch: fix-auth-bug
 Path:   /path/to/workspace
@@ -123,10 +124,9 @@ Example:
 ```text
 ❌ Failed to create workspace
 
-Error: workspace name 'test' already exists
+Error: {specific error message from the operation}
 
-Use a different name or remove the existing workspace:
-  amux ws remove test
+{Optional helpful hint or suggestion}
 ```
 
 ### List Displays

--- a/docs/cli-output-guidelines.md
+++ b/docs/cli-output-guidelines.md
@@ -1,0 +1,283 @@
+# CLI Output Design Guidelines
+
+This document establishes the design principles and patterns for consistent CLI output across all amux commands.
+
+## Design Principles
+
+### 1. Minimalism
+
+- Use visual elements sparingly and purposefully
+- Every icon, color, or decoration must serve a clear function
+- Prefer clean, undecorated text for most output
+
+### 2. Hierarchy
+
+- Create clear visual distinction between different information levels
+- Use indentation to show relationships
+- Group related information together
+
+### 3. Consistency
+
+- Apply the same patterns across all commands
+- Use the same visual language for similar concepts
+- Maintain predictable output formats
+
+### 4. Functionality
+
+- Prioritize readability over decoration
+- Ensure output is parseable and scriptable where appropriate
+- Support both human and machine consumption
+
+## Visual Elements Usage
+
+### Icons
+
+#### When to Use Icons
+
+- **Section headers**: To identify major output sections
+- **Final status**: Success (✅), Error (❌), Warning (⚠️)
+- **Entity types**: Workspace (📋), Session (🔄), etc. (sparingly)
+
+#### When NOT to Use Icons
+
+- Consecutive detail lines
+- Every line of a list
+- Key-value pairs
+- Progress steps (unless final status)
+
+#### Icon Guidelines
+
+```text
+✅ Success - Use only for final successful completion
+❌ Error - Use only for actual errors that need attention
+⚠️  Warning - Use only for important warnings
+ⓘ  Info - AVOID; rarely needed
+📋 Entity icons - Use only in headers, not in lists
+```
+
+### Colors
+
+#### Color Palette
+
+- **Default**: Terminal default (no color)
+- **Success**: Green (#00D26A) - Sparingly, for final results
+- **Error**: Red (#F85149) - Only for actual errors
+- **Warning**: Yellow (#F0AD4E) - Only for important warnings
+- **Info**: Blue (#0969DA) - Rarely needed
+- **Dim**: Gray (#6E7781) - For metadata
+
+#### Color Usage Rules
+
+1. Use color only where it adds meaning
+2. Never use color as the only distinguisher
+3. Ensure output is readable without color
+4. Test with both light and dark themes
+
+### Text Formatting
+
+#### Bold
+
+- Command names in help text
+- Important values that need emphasis
+- Section headers (sparingly)
+
+#### Dim/Gray
+
+- Metadata (IDs, timestamps, ages)
+- Supplementary information
+- Hints and suggestions
+
+## Output Patterns
+
+### Success Messages
+
+```text
+✅ {Action} completed successfully
+
+{Optional details without icons}
+```
+
+Example:
+
+```text
+✅ Workspace created successfully
+
+Name:   fix-auth-bug
+ID:     3
+Branch: fix-auth-bug
+Path:   /path/to/workspace
+```
+
+### Error Messages
+
+```text
+❌ Failed to {action}
+
+Error: {specific error message}
+
+{Optional hint without icon}
+```
+
+Example:
+
+```text
+❌ Failed to create workspace
+
+Error: workspace name 'test' already exists
+
+Use a different name or remove the existing workspace:
+  amux ws remove test
+```
+
+### List Displays
+
+```text
+{Icon} {Entity} ({count})
+
+{Table with headers in caps}
+```
+
+Example:
+
+```text
+📋 Workspaces (3)
+
+ID  NAME            BRANCH          AGE     STATUS
+1   fix-auth-bug    fix-auth-bug    2h      ✓ ok
+2   feat-api        feat-api        1d      ✓ ok
+3   refactor-cli    main            3d      ⚠ folder missing
+```
+
+### Detail Views
+
+```text
+{Entity}: {name}
+
+  {Key}:     {value}
+  {Key}:     {value}
+
+  {Section}:
+    {Key}:   {value}
+    {Key}:   {value}
+```
+
+Example:
+
+```text
+Workspace: fix-auth-bug
+
+  Name:        fix-auth-bug
+  Description: Fix authentication timeout issue
+  Branch:      fix-auth-bug
+  Status:      ✓ Consistent
+
+  Created:     2024-01-15 10:30:15 (2 hours ago)
+  Updated:     2024-01-15 12:45:30 (15 minutes ago)
+
+  Paths:
+    Worktree:  /path/to/worktree
+    Storage:   /path/to/storage
+    Context:   /path/to/context.md
+```
+
+### Progress Indication
+
+For operations taking less than 3 seconds: No progress indication needed
+
+For longer operations (future):
+
+```text
+{Action}...
+
+  {Step 1}...    done
+  {Step 2}...    done
+  {Step 3}...    in progress
+```
+
+### Prompts
+
+```text
+{Question or warning}
+
+{Optional details}
+
+{Prompt} [{default}]:
+```
+
+Example:
+
+```text
+⚠️  This will permanently delete the workspace 'feat-old'
+
+Do you want to continue? [y/N]:
+```
+
+## Implementation Guidelines
+
+### Using the UI Package
+
+#### Preferred Functions
+
+- `ui.Success()` - Only for final success messages
+- `ui.Error()` - Only for actual errors
+- `ui.Warning()` - Only for important warnings
+- `ui.Output()` / `ui.OutputLine()` - For most output
+- `ui.PrintKeyValue()` - For consistent key-value pairs
+
+#### Avoid Overuse
+
+- Don't use `ui.Info()` for consecutive lines
+- Don't add icons to every line
+- Don't color every piece of text
+
+### Examples
+
+#### Bad (Current)
+
+```go
+ui.Info("ID: %s", ws.Index)
+ui.Info("Branch: %s", ws.Branch)
+ui.Info("Path: %s", ws.Path)
+```
+
+#### Good (Improved)
+
+```go
+ui.Success("Workspace created successfully")
+ui.OutputLine("")
+ui.PrintKeyValue("ID", ws.Index)
+ui.PrintKeyValue("Branch", ws.Branch)
+ui.PrintKeyValue("Path", ws.Path)
+```
+
+## Testing Guidelines
+
+1. Test output with both light and dark terminal themes
+2. Verify output is readable without color support
+3. Ensure output is parseable for scripting
+4. Check alignment and formatting with various data lengths
+5. Validate that important information stands out
+
+## Future Considerations
+
+### Animations
+
+- Reserved for operations taking >3 seconds
+- Use sparingly and only when it improves UX
+- Consider spinner for indefinite waits
+- Consider progress bar for determinate operations
+
+### Interactive Elements
+
+- Keep prompts simple and clear
+- Provide sensible defaults
+- Show what will happen before confirmation
+- Allow escape/cancellation
+
+## Accessibility
+
+1. Never rely solely on color to convey information
+2. Use clear, descriptive text
+3. Maintain consistent patterns
+4. Support screen readers where possible
+5. Provide alternative text formats when needed

--- a/docs/cli-output-guidelines.md
+++ b/docs/cli-output-guidelines.md
@@ -34,8 +34,8 @@ This document establishes the design principles and patterns for consistent CLI 
 
 #### When to Use Icons
 
+- **Result headers**: Success (✅), Error (❌), Warning (⚠️) for operation outcomes
 - **Section headers**: To identify major output sections
-- **Final status**: Success (✅), Error (❌), Warning (⚠️)
 - **Entity types**: Workspace (📋), Session (🔄), etc. (sparingly)
 
 #### When NOT to Use Icons
@@ -48,11 +48,11 @@ This document establishes the design principles and patterns for consistent CLI 
 #### Icon Guidelines
 
 ```text
-✅ Success - Use only for final successful completion
-❌ Error - Use only for actual errors that need attention
-⚠️  Warning - Use only for important warnings
+✅ Success - Use for operation result headers (completion messages)
+❌ Error - Use for operation result headers (failure messages)
+⚠️  Warning - Use for operation result headers (warning messages)
 ⓘ  Info - AVOID; rarely needed
-📋 Entity icons - Use only in headers, not in lists
+📋 Entity icons - Use only in section headers, not in lists
 ```
 
 ### Colors
@@ -92,17 +92,17 @@ This document establishes the design principles and patterns for consistent CLI 
 ### Success Messages
 
 ```text
-{Action message or confirmation}
+✅ {Action} completed successfully
 
 {Optional details without icons}
 ```
 
-Note: The ✅ icon should be used sparingly, only for final completion of major operations.
+Note: Use the ✅ icon for result headers to provide clear visual confirmation of successful operations.
 
 Example:
 
 ```text
-Created workspace 'fix-auth-bug'
+✅ Workspace created successfully
 
 ID:     3
 Branch: fix-auth-bug

--- a/internal/cli/commands/config_validate.go
+++ b/internal/cli/commands/config_validate.go
@@ -66,31 +66,31 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 
 	// Show configuration details if verbose
 	if verbose {
-		ui.Info("")
-		ui.Info("Configuration details:")
-		ui.Info("  Version: %s", cfg.Version)
+		ui.OutputLine("")
+		ui.OutputLine("Configuration details:")
+		ui.OutputLine("  Version: %s", cfg.Version)
 
-		ui.Info("")
-		ui.Info("MCP Configuration:")
-		ui.Info("  Transport: %s", cfg.MCP.Transport.Type)
+		ui.OutputLine("")
+		ui.OutputLine("MCP Configuration:")
+		ui.OutputLine("  Transport: %s", cfg.MCP.Transport.Type)
 
 		if len(cfg.Agents) > 0 {
-			ui.Info("")
-			ui.Info("Agents (%d configured):", len(cfg.Agents))
+			ui.OutputLine("")
+			ui.OutputLine("Agents (%d configured):", len(cfg.Agents))
 			for id, agent := range cfg.Agents {
-				ui.Info("  %s:", id)
-				ui.Info("    Name: %s", agent.Name)
-				ui.Info("    Type: %s", agent.Type)
+				ui.OutputLine("  %s:", id)
+				ui.OutputLine("    Name: %s", agent.Name)
+				ui.OutputLine("    Type: %s", agent.Type)
 
 				switch agent.Type {
 				case config.AgentTypeTmux:
 					if params, err := agent.GetTmuxParams(); err == nil {
-						ui.Info("    Command: %s", params.Command)
+						ui.OutputLine("    Command: %s", params.Command)
 						if params.Shell != "" {
-							ui.Info("    Shell: %s", params.Shell)
+							ui.OutputLine("    Shell: %s", params.Shell)
 						}
 						if params.WindowName != "" {
-							ui.Info("    Window Name: %s", params.WindowName)
+							ui.OutputLine("    Window Name: %s", params.WindowName)
 						}
 					}
 				case config.AgentTypeClaudeCode, config.AgentTypeAPI:
@@ -98,16 +98,16 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 				}
 
 				if agent.Description != "" {
-					ui.Info("    Description: %s", agent.Description)
+					ui.OutputLine("    Description: %s", agent.Description)
 				}
 
 				if len(agent.Environment) > 0 {
-					ui.Info("    Environment Variables: %d", len(agent.Environment))
+					ui.OutputLine("    Environment Variables: %d", len(agent.Environment))
 				}
 			}
 		} else {
-			ui.Info("")
-			ui.Info("No agents configured")
+			ui.OutputLine("")
+			ui.OutputLine("No agents configured")
 		}
 	}
 

--- a/internal/cli/commands/hooks.go
+++ b/internal/cli/commands/hooks.go
@@ -149,28 +149,28 @@ func trustHooks(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display hooks for review
-	ui.Info("Review the following hooks before trusting:")
-	ui.Info("")
+	ui.OutputLine("Review the following hooks before trusting:")
+	ui.OutputLine("")
 
 	for event, hookList := range hooksConfig.Hooks {
 		if len(hookList) == 0 {
 			continue
 		}
 
-		ui.Info("%s:", event)
+		ui.OutputLine("%s:", event)
 		for i, hook := range hookList {
 			cmdStr := hook.Command
 			if cmdStr == "" {
 				cmdStr = hook.Script
 			}
-			ui.Info("  %d. \"%s\" - %s", i+1, hook.Name, cmdStr)
+			ui.OutputLine("  %d. \"%s\" - %s", i+1, hook.Name, cmdStr)
 		}
-		ui.Info("")
+		ui.OutputLine("")
 	}
 
 	// Ask for confirmation
 	if !ui.Confirm("Trust these hooks?") {
-		ui.Info("Hooks not trusted.")
+		ui.OutputLine("Hooks not trusted.")
 		return nil
 	}
 
@@ -218,13 +218,13 @@ func listHooks(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display hooks
-	ui.Output("Hooks configuration (%s):", func() string {
+	ui.OutputLine("Hooks configuration (%s):", func() string {
 		if trusted {
 			return "trusted"
 		}
 		return "not trusted"
 	}())
-	ui.Output("")
+	ui.OutputLine("")
 
 	hasHooks := false
 	for event, hookList := range hooksConfig.Hooks {
@@ -233,32 +233,33 @@ func listHooks(cmd *cobra.Command, args []string) error {
 		}
 
 		hasHooks = true
-		ui.Output("%s:", event)
+		ui.OutputLine("%s:", event)
 		for i, hook := range hookList {
 			cmdStr := hook.Command
 			if cmdStr == "" {
 				cmdStr = fmt.Sprintf("script: %s", hook.Script)
 			}
-			ui.Output("  %d. %s", i+1, hook.Name)
-			ui.Output("     Command: %s", cmdStr)
-			ui.Output("     Timeout: %s", hook.Timeout)
-			ui.Output("     On error: %s", hook.OnError)
+			ui.OutputLine("  %d. %s", i+1, hook.Name)
+			ui.OutputLine("     Command: %s", cmdStr)
+			ui.OutputLine("     Timeout: %s", hook.Timeout)
+			ui.OutputLine("     On error: %s", hook.OnError)
 			if len(hook.Env) > 0 {
-				ui.Output("     Environment:")
+				ui.OutputLine("     Environment:")
 				for k, v := range hook.Env {
-					ui.Output("       %s=%s", k, v)
+					ui.OutputLine("       %s=%s", k, v)
 				}
 			}
-			ui.Output("")
+			ui.OutputLine("")
 		}
 	}
 
 	if !hasHooks {
-		ui.Info("No hooks configured.")
-		ui.Info("Run 'amux hooks init' to create an example configuration.")
+		ui.OutputLine("No hooks configured.")
+		ui.OutputLine("Run 'amux hooks init' to create an example configuration.")
 	} else if !trusted {
-		ui.Warning("Hooks are configured but not trusted.")
-		ui.Info("Run 'amux hooks trust' to enable them.")
+		ui.Warning("Hooks are configured but not trusted")
+		ui.OutputLine("")
+		ui.OutputLine("Run 'amux hooks trust' to enable them.")
 	}
 
 	return nil
@@ -295,29 +296,29 @@ func testHooks(cmd *cobra.Command, args []string) error {
 	// Get hooks for event
 	eventHooks := hooksConfig.GetHooksForEvent(event)
 	if len(eventHooks) == 0 {
-		ui.Info("No hooks configured for event '%s'", event)
+		ui.OutputLine("No hooks configured for event '%s'", event)
 		return nil
 	}
 
 	// Show what would be executed
-	ui.Info("Hooks that would run for '%s':", event)
+	ui.OutputLine("Hooks that would run for '%s':", event)
 	for i, hook := range eventHooks {
 		cmdStr := hook.Command
 		if cmdStr == "" {
 			cmdStr = hook.Script
 		}
-		ui.Info("  %d. \"%s\"", i+1, hook.Name)
-		ui.Info("     Would execute: %s", cmdStr)
-		ui.Info("     Timeout: %s", hook.Timeout)
-		ui.Info("     On error: %s", hook.OnError)
+		ui.OutputLine("  %d. \"%s\"", i+1, hook.Name)
+		ui.OutputLine("     Would execute: %s", cmdStr)
+		ui.OutputLine("     Timeout: %s", hook.Timeout)
+		ui.OutputLine("     On error: %s", hook.OnError)
 	}
 
-	ui.Info("")
-	ui.Info("Environment variables that would be set:")
-	ui.Info("  AMUX_EVENT=%s", event)
-	ui.Info("  AMUX_PROJECT_ROOT=%s", projectRoot)
-	ui.Info("  AMUX_CONFIG_DIR=%s", configDir)
-	ui.Info("  (Plus workspace/agent specific variables when applicable)")
+	ui.OutputLine("")
+	ui.OutputLine("Environment variables that would be set:")
+	ui.OutputLine("  AMUX_EVENT=%s", event)
+	ui.OutputLine("  AMUX_PROJECT_ROOT=%s", projectRoot)
+	ui.OutputLine("  AMUX_CONFIG_DIR=%s", configDir)
+	ui.OutputLine("  (Plus workspace/agent specific variables when applicable)")
 
 	return nil
 }

--- a/internal/cli/commands/hooks.go
+++ b/internal/cli/commands/hooks.go
@@ -115,8 +115,8 @@ func initHooks(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save hooks configuration: %w", err)
 	}
 
-	ui.Success("Created hooks configuration at %s", hooksPath)
-	ui.Info("Edit this file to configure your hooks, then run 'amux hooks trust' to enable them.")
+	ui.OutputLine("Created hooks configuration at %s", hooksPath)
+	ui.OutputLine("Edit this file to configure your hooks, then run 'amux hooks trust' to enable them.")
 
 	return nil
 }
@@ -191,7 +191,7 @@ func trustHooks(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save trust information: %w", err)
 	}
 
-	ui.Success("Hooks trusted. They will now run automatically during workspace operations.")
+	ui.OutputLine("Hooks trusted. They will now run automatically during workspace operations.")
 	return nil
 }
 

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -71,7 +71,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ui.OutputLine("Initialized Amux in %s", cwd)
+	ui.Success("Amux initialized successfully in %s", cwd)
 	ui.PrintKeyValue("Configuration", filepath.Join(config.AmuxDir, config.ConfigFile))
 	ui.OutputLine("\nRun 'amux mcp' to start the MCP server")
 

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -66,16 +66,14 @@ func runInit(cmd *cobra.Command, args []string) error {
 			if err := addToGitignore(cwd); err != nil {
 				ui.Warning("Failed to update .gitignore: %v", err)
 			} else {
-				ui.Success("Added .amux/ to .gitignore")
+				ui.OutputLine("Added .amux/ to .gitignore")
 			}
 		}
 	}
 
-	ui.Success("Initialized Amux in %s", cwd)
-	ui.OutputLine("")
+	ui.OutputLine("Initialized Amux in %s", cwd)
 	ui.PrintKeyValue("Configuration", filepath.Join(config.AmuxDir, config.ConfigFile))
-	ui.OutputLine("")
-	ui.OutputLine("Run 'amux mcp' to start the MCP server")
+	ui.OutputLine("\nRun 'amux mcp' to start the MCP server")
 
 	return nil
 }

--- a/internal/cli/commands/init.go
+++ b/internal/cli/commands/init.go
@@ -72,8 +72,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.Success("Initialized Amux in %s", cwd)
-	ui.Info("Configuration saved to %s", filepath.Join(config.AmuxDir, config.ConfigFile))
-	ui.Info("Run 'amux mcp' to start the MCP server")
+	ui.OutputLine("")
+	ui.PrintKeyValue("Configuration", filepath.Join(config.AmuxDir, config.ConfigFile))
+	ui.OutputLine("")
+	ui.OutputLine("Run 'amux mcp' to start the MCP server")
 
 	return nil
 }

--- a/internal/cli/commands/session/attach.go
+++ b/internal/cli/commands/session/attach.go
@@ -81,7 +81,7 @@ func attachSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Execute tmux attach
-	ui.Info("Attaching to session %s...", sessionID)
+	ui.OutputLine("Attaching to session %s...", sessionID)
 	tmuxCmd := exec.Command("tmux", "attach-session", "-t", info.TmuxSession)
 	tmuxCmd.Stdin = os.Stdin
 	tmuxCmd.Stdout = os.Stdout

--- a/internal/cli/commands/session/hooks.go
+++ b/internal/cli/commands/session/hooks.go
@@ -45,8 +45,8 @@ func executeSessionHooks(sess session.Session, ws *workspace.Workspace, event ho
 	}
 
 	if !trusted {
-		ui.Warning("This project has hooks configured but they are not trusted.")
-		ui.Info("Run 'amux hooks trust' to trust hooks in this project.")
+		ui.Warning("This project has hooks configured but they are not trusted")
+		ui.OutputLine("Run 'amux hooks trust' to trust hooks in this project.")
 		return nil
 	}
 

--- a/internal/cli/commands/session/list.go
+++ b/internal/cli/commands/session/list.go
@@ -51,7 +51,7 @@ func listSessions(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(sessions) == 0 {
-		ui.Info("No active sessions found")
+		ui.OutputLine("No active sessions found")
 		return nil
 	}
 

--- a/internal/cli/commands/session/logs.go
+++ b/internal/cli/commands/session/logs.go
@@ -133,12 +133,12 @@ func streamSessionLogs(sess session.Session) error {
 	err = tailer.Follow(ctx)
 
 	if err == context.Canceled {
-		ui.Info("\nStopped following logs")
+		ui.OutputLine("\nStopped following logs")
 		return nil
 	}
 
 	if err == nil {
-		ui.Info("\nSession ended")
+		ui.OutputLine("\nSession ended")
 		return nil
 	}
 

--- a/internal/cli/commands/session/remove.go
+++ b/internal/cli/commands/session/remove.go
@@ -78,7 +78,7 @@ func removeSession(cmd *cobra.Command, args []string, keepWorkspace bool) error 
 		return fmt.Errorf("failed to remove session: %w", err)
 	}
 
-	ui.OutputLine("Session %s removed", sessionID)
+	ui.Success("Session removed successfully: %s", sessionID)
 
 	// Check if workspace was auto-created and --keep-workspace was not specified
 	if !keepWorkspace && workspaceID != "" {

--- a/internal/cli/commands/session/remove.go
+++ b/internal/cli/commands/session/remove.go
@@ -78,7 +78,7 @@ func removeSession(cmd *cobra.Command, args []string, keepWorkspace bool) error 
 		return fmt.Errorf("failed to remove session: %w", err)
 	}
 
-	ui.Success("Session %s removed", sessionID)
+	ui.OutputLine("Session %s removed", sessionID)
 
 	// Check if workspace was auto-created and --keep-workspace was not specified
 	if !keepWorkspace && workspaceID != "" {
@@ -112,7 +112,7 @@ func removeSession(cmd *cobra.Command, args []string, keepWorkspace bool) error 
 				if err := wsManager.Remove(cmd.Context(), workspace.Identifier(workspaceID)); err != nil {
 					ui.Warning("Failed to remove auto-created workspace %s: %v", ws.Name, err)
 				} else {
-					ui.Success("Removed auto-created workspace: '%s'", ws.Name)
+					ui.OutputLine("Removed auto-created workspace: '%s'", ws.Name)
 				}
 			} else {
 				ui.Info("Auto-created workspace not removed (still in use by other sessions)")

--- a/internal/cli/commands/session/run.go
+++ b/internal/cli/commands/session/run.go
@@ -94,7 +94,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create auto-workspace: %w", err)
 		}
-		ui.Success("Created workspace '%s'", ws.Name)
+		ui.OutputLine("Created workspace '%s'", ws.Name)
 	}
 
 	// Create agent manager
@@ -175,9 +175,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
 
-	ui.Success("Session started successfully")
-	ui.OutputLine("")
-	ui.PrintKeyValue("Session", displayID)
+	ui.OutputLine("Session %s started", displayID)
 	ui.PrintKeyValue("Workspace", ws.Name)
 	ui.PrintKeyValue("Agent", agentID)
 
@@ -205,8 +203,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 
 		// Check if we can auto-attach (TTY available and autoAttach enabled)
 		if shouldAutoAttach && term.IsTerminal(os.Stdin.Fd()) {
-			ui.OutputLine("")
-			ui.OutputLine("Auto-attaching to session...")
+			ui.OutputLine("\nAuto-attaching to session...")
 			tmuxCmd := exec.Command("tmux", "attach-session", "-t", info.TmuxSession)
 			tmuxCmd.Stdin = os.Stdin
 			tmuxCmd.Stdout = os.Stdout
@@ -215,8 +212,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 		}
 
 		// Show manual attach instructions
-		ui.OutputLine("")
-		ui.OutputLine("To attach to this session, run:")
+		ui.OutputLine("\nTo attach to this session, run:")
 		ui.OutputLine("  tmux attach-session -t %s", info.TmuxSession)
 		attachID := sess.ID()
 		if info.Index != "" {

--- a/internal/cli/commands/session/run.go
+++ b/internal/cli/commands/session/run.go
@@ -94,7 +94,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create auto-workspace: %w", err)
 		}
-		ui.OutputLine("Created workspace '%s'", ws.Name)
+		ui.Success("Workspace created successfully: %s", ws.Name)
 	}
 
 	// Create agent manager
@@ -175,7 +175,9 @@ func runSession(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
 
-	ui.OutputLine("Session %s started", displayID)
+	ui.Success("Session started successfully")
+	ui.OutputLine("")
+	ui.PrintKeyValue("Session", displayID)
 	ui.PrintKeyValue("Workspace", ws.Name)
 	ui.PrintKeyValue("Agent", agentID)
 

--- a/internal/cli/commands/session/run.go
+++ b/internal/cli/commands/session/run.go
@@ -94,7 +94,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create auto-workspace: %w", err)
 		}
-		ui.Success("Created workspace: '%s'", ws.Name)
+		ui.Success("Created workspace '%s'", ws.Name)
 	}
 
 	// Create agent manager
@@ -170,15 +170,16 @@ func runSession(cmd *cobra.Command, args []string) error {
 		displayID = info.Index
 	}
 
-	// Show consistent session creation info with workspace name
-	ui.Success("Started session: %s in workspace '%s'", displayID, ws.Name)
-
 	// Start session
 	if err := sess.Start(cmd.Context()); err != nil {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
 
-	ui.Success("Agent session started successfully!")
+	ui.Success("Session started successfully")
+	ui.OutputLine("")
+	ui.PrintKeyValue("Session", displayID)
+	ui.PrintKeyValue("Workspace", ws.Name)
+	ui.PrintKeyValue("Agent", agentID)
 
 	// Execute session start hooks
 	if err := executeSessionHooks(sess, ws, hooks.EventSessionStart); err != nil {
@@ -204,7 +205,8 @@ func runSession(cmd *cobra.Command, args []string) error {
 
 		// Check if we can auto-attach (TTY available and autoAttach enabled)
 		if shouldAutoAttach && term.IsTerminal(os.Stdin.Fd()) {
-			ui.Info("Auto-attaching to session...")
+			ui.OutputLine("")
+			ui.OutputLine("Auto-attaching to session...")
 			tmuxCmd := exec.Command("tmux", "attach-session", "-t", info.TmuxSession)
 			tmuxCmd.Stdin = os.Stdin
 			tmuxCmd.Stdout = os.Stdout
@@ -213,13 +215,14 @@ func runSession(cmd *cobra.Command, args []string) error {
 		}
 
 		// Show manual attach instructions
-		ui.Info("To attach to this session, run:")
-		ui.Info("  tmux attach-session -t %s", info.TmuxSession)
+		ui.OutputLine("")
+		ui.OutputLine("To attach to this session, run:")
+		ui.OutputLine("  tmux attach-session -t %s", info.TmuxSession)
 		attachID := sess.ID()
 		if info.Index != "" {
 			attachID = info.Index
 		}
-		ui.Info("  or: amux attach %s", attachID)
+		ui.OutputLine("  or: amux attach %s", attachID)
 	}
 
 	return nil

--- a/internal/cli/commands/session/send_input.go
+++ b/internal/cli/commands/session/send_input.go
@@ -86,9 +86,7 @@ func sendInputToSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display success message
-	info := sess.Info()
-	ui.Success("Input sent to session %s (agent: %s, workspace: %s)",
-		sessionID, info.AgentID, info.WorkspaceID)
+	ui.OutputLine("Input sent to session %s", sessionID)
 
 	return nil
 }

--- a/internal/cli/commands/session/stop.go
+++ b/internal/cli/commands/session/stop.go
@@ -69,6 +69,6 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to stop session: %w", err)
 	}
 
-	ui.Success("Session %s stopped", sessionID)
+	ui.OutputLine("Session %s stopped", sessionID)
 	return nil
 }

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -201,17 +201,16 @@ func runCreateWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create workspace: %w", err)
 	}
 
-	ui.Success("Created workspace: %s", ws.Name)
+	ui.Success("Workspace created successfully")
+	ui.OutputLine("")
 
 	if ws.Index != "" {
-		ui.Info("ID: %s", ws.Index)
+		ui.PrintKeyValue("ID", ws.Index)
 	} else {
-		ui.Info("ID: %s", ws.ID)
+		ui.PrintKeyValue("ID", ws.ID)
 	}
-
-	ui.Info("Branch: %s", ws.Branch)
-
-	ui.Info("Path: %s", ws.Path)
+	ui.PrintKeyValue("Branch", ws.Branch)
+	ui.PrintKeyValue("Path", ws.Path)
 
 	// Execute hooks unless --no-hooks was specified
 	if !createNoHooks {
@@ -326,10 +325,11 @@ func runRemoveWorkspace(cmd *cobra.Command, args []string) error {
 	// Check both original and resolved paths
 	if strings.HasPrefix(cwd, ws.Path) || strings.HasPrefix(resolvedCwd, ws.Path) {
 		ui.Error("Cannot remove workspace while working inside it")
-		ui.Info("Please change to a different directory first:")
+		ui.OutputLine("")
+		ui.OutputLine("Please change to a different directory first:")
 		projectRoot, _ := config.FindProjectRoot()
 		if projectRoot != "" {
-			ui.Info("  cd %s", projectRoot)
+			ui.OutputLine("  cd %s", projectRoot)
 		}
 		return fmt.Errorf("cannot remove workspace from within itself")
 	}
@@ -341,7 +341,7 @@ func runRemoveWorkspace(cmd *cobra.Command, args []string) error {
 		response := ui.Prompt("Are you sure? (y/N): ")
 
 		if response != "y" && response != "Y" {
-			ui.Info("Removal cancelled")
+			ui.OutputLine("Removal cancelled")
 			return nil
 		}
 
@@ -383,17 +383,14 @@ func runPruneWorkspace(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(removed) == 0 {
-
-		ui.Info("No workspaces to prune")
-
+		ui.OutputLine("No workspaces to prune")
 		return nil
-
 	}
 
 	if pruneDryRun {
-		ui.Info("Would remove %d workspace(s):", len(removed))
+		ui.OutputLine("Would remove %d workspace(s):", len(removed))
 	} else {
-		ui.Success("Removed %d workspace(s):", len(removed))
+		ui.Success("Removed %d workspace(s)", len(removed))
 	}
 
 	for _, id := range removed {
@@ -438,9 +435,10 @@ func runCdWorkspace(cmd *cobra.Command, args []string) error {
 	)
 
 	// Print information about entering the workspace
-	ui.Info("Entering workspace: %s", ws.Name)
-	ui.Info("Path: %s", ws.Path)
-	ui.Info("Exit the shell to return to your original directory")
+	ui.OutputLine("Entering workspace: %s", ws.Name)
+	ui.PrintKeyValue("Path", ws.Path)
+	ui.OutputLine("")
+	ui.OutputLine("Exit the shell to return to your original directory")
 
 	// Run the shell
 	if err := shellCmd.Run(); err != nil {
@@ -508,8 +506,9 @@ func executeWorkspaceHooks(ws *workspace.Workspace, event hooks.Event) error {
 	}
 
 	if !trusted {
-		ui.Warning("This project has hooks configured but they are not trusted.")
-		ui.Info("Run 'amux hooks trust' to trust hooks in this project.")
+		ui.Warning("This project has hooks configured but they are not trusted")
+		ui.OutputLine("")
+		ui.OutputLine("Run 'amux hooks trust' to trust hooks in this project.")
 		return nil
 	}
 

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -205,7 +205,8 @@ func runCreateWorkspace(cmd *cobra.Command, args []string) error {
 	if ws.Index != "" {
 		id = ws.Index
 	}
-	ui.OutputLine("Created workspace '%s'", ws.Name)
+	ui.Success("Workspace created successfully")
+	ui.OutputLine("")
 	ui.PrintKeyValue("ID", id)
 	ui.PrintKeyValue("Branch", ws.Branch)
 	ui.PrintKeyValue("Path", ws.Path)
@@ -357,7 +358,7 @@ func runRemoveWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to remove workspace: %w", err)
 	}
 
-	ui.OutputLine("Removed workspace: %s (%s)", ws.Name, ws.ID)
+	ui.Success("Workspace removed successfully: %s (%s)", ws.Name, ws.ID)
 
 	return nil
 }

--- a/internal/cli/commands/workspace.go
+++ b/internal/cli/commands/workspace.go
@@ -201,14 +201,12 @@ func runCreateWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create workspace: %w", err)
 	}
 
-	ui.Success("Workspace created successfully")
-	ui.OutputLine("")
-
+	id := ws.ID
 	if ws.Index != "" {
-		ui.PrintKeyValue("ID", ws.Index)
-	} else {
-		ui.PrintKeyValue("ID", ws.ID)
+		id = ws.Index
 	}
+	ui.OutputLine("Created workspace '%s'", ws.Name)
+	ui.PrintKeyValue("ID", id)
 	ui.PrintKeyValue("Branch", ws.Branch)
 	ui.PrintKeyValue("Path", ws.Path)
 
@@ -325,8 +323,7 @@ func runRemoveWorkspace(cmd *cobra.Command, args []string) error {
 	// Check both original and resolved paths
 	if strings.HasPrefix(cwd, ws.Path) || strings.HasPrefix(resolvedCwd, ws.Path) {
 		ui.Error("Cannot remove workspace while working inside it")
-		ui.OutputLine("")
-		ui.OutputLine("Please change to a different directory first:")
+		ui.OutputLine("\nPlease change to a different directory first:")
 		projectRoot, _ := config.FindProjectRoot()
 		if projectRoot != "" {
 			ui.OutputLine("  cd %s", projectRoot)
@@ -360,7 +357,7 @@ func runRemoveWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to remove workspace: %w", err)
 	}
 
-	ui.Success("Removed workspace: %s (%s)", ws.Name, ws.ID)
+	ui.OutputLine("Removed workspace: %s (%s)", ws.Name, ws.ID)
 
 	return nil
 }
@@ -390,7 +387,7 @@ func runPruneWorkspace(cmd *cobra.Command, args []string) error {
 	if pruneDryRun {
 		ui.OutputLine("Would remove %d workspace(s):", len(removed))
 	} else {
-		ui.Success("Removed %d workspace(s)", len(removed))
+		ui.OutputLine("Removed %d workspace(s)", len(removed))
 	}
 
 	for _, id := range removed {
@@ -437,8 +434,7 @@ func runCdWorkspace(cmd *cobra.Command, args []string) error {
 	// Print information about entering the workspace
 	ui.OutputLine("Entering workspace: %s", ws.Name)
 	ui.PrintKeyValue("Path", ws.Path)
-	ui.OutputLine("")
-	ui.OutputLine("Exit the shell to return to your original directory")
+	ui.OutputLine("\nExit the shell to return to your original directory")
 
 	// Run the shell
 	if err := shellCmd.Run(); err != nil {
@@ -507,7 +503,6 @@ func executeWorkspaceHooks(ws *workspace.Workspace, event hooks.Event) error {
 
 	if !trusted {
 		ui.Warning("This project has hooks configured but they are not trusted")
-		ui.OutputLine("")
 		ui.OutputLine("Run 'amux hooks trust' to trust hooks in this project.")
 		return nil
 	}

--- a/internal/core/hooks/executor.go
+++ b/internal/core/hooks/executor.go
@@ -56,7 +56,8 @@ func (e *Executor) ExecuteHooks(event Event, hooks []Hook) error {
 		return nil
 	}
 
-	ui.Info("Running hooks for '%s'...", event)
+	ui.OutputLine("")
+	ui.OutputLine("Running hooks for '%s'...", event)
 
 	for i, hook := range hooks {
 		result, err := e.executeHook(&hook, i+1, len(hooks))
@@ -77,7 +78,8 @@ func (e *Executor) ExecuteHooks(event Event, hooks []Hook) error {
 		}
 	}
 
-	ui.Success("All hooks completed successfully")
+	ui.OutputLine("")
+	ui.Success("Hooks completed successfully")
 	return nil
 }
 
@@ -111,10 +113,10 @@ func (e *Executor) executeHook(hook *Hook, index, total int) (*ExecutionResult, 
 	}
 
 	// Show progress
-	ui.Info("  [%d/%d] %s", index, total, hook.Name)
+	ui.OutputLine("  [%d/%d] %s", index, total, hook.Name)
 
 	if e.dryRun {
-		ui.Info("    > [DRY RUN] Would execute: %s", cmdStr)
+		ui.OutputLine("    > [DRY RUN] Would execute: %s", cmdStr)
 		return &ExecutionResult{Hook: hook}, nil
 	}
 
@@ -173,12 +175,12 @@ func (e *Executor) executeHook(hook *Hook, index, total int) (*ExecutionResult, 
 		}
 
 		duration := result.EndTime.Sub(result.StartTime)
-		ui.Error("  ✗ [%d/%d] %s - failed in %.1fs", index, total, hook.Name, duration.Seconds())
+		ui.OutputLine("    ✗ Failed in %.1fs", duration.Seconds())
 		return result, err
 	}
 
 	duration := result.EndTime.Sub(result.StartTime)
-	ui.Success("  ✓ [%d/%d] %s - completed in %.1fs", index, total, hook.Name, duration.Seconds())
+	ui.OutputLine("    ✓ Completed in %.1fs", duration.Seconds())
 
 	return result, nil
 }


### PR DESCRIPTION
## Summary

This PR standardizes CLI output design across all amux commands to create a consistent, calm, and modern user experience.

## Problem

- Excessive use of Info icons (ⓘ) for consecutive lines of output
- Inconsistent formatting patterns across different commands
- Visual noise from too many icons making output busy and less clear

## Changes

- Created comprehensive CLI output design guidelines (`docs/cli-output-guidelines.md`)
- Replaced excessive `ui.Info()` usage with `ui.OutputLine()` in:
  - `workspace.go` - Workspace creation, removal, pruning, and cd commands
  - `config_validate.go` - Verbose configuration output
  - `hooks.go` - Hook listing and testing output
  - `init.go` - Initialization success output
- Improved visual hierarchy with proper spacing and key-value formatting
- Reserved icons for section headers and final status only

## Examples

### Before
```
ⓘ ID: 3
ⓘ Branch: fix-auth-bug
ⓘ Path: /path/to/workspace
```

### After
```
✅ Workspace created successfully

ID:     3
Branch: fix-auth-bug
Path:   /path/to/workspace
```

## Testing

- All tests pass (`just test`)
- All formatting and linting checks pass (`just check`)
- Manually tested affected commands to ensure proper output formatting

Fixes #184