### PR TITLE
feat: add StatusOrphaned for sessions with deleted workspaces

### DIFF
--- a/internal/cli/commands/session/list.go
+++ b/internal/cli/commands/session/list.go
@@ -71,6 +71,9 @@ func listSessions(cmd *cobra.Command, args []string) error {
 		wsName := info.WorkspaceID
 		if err == nil {
 			wsName = ws.Name
+		} else if info.StatusState.Status == session.StatusOrphaned {
+			// Show "(deleted)" suffix for orphaned sessions
+			wsName = fmt.Sprintf("%s (deleted)", info.WorkspaceID)
 		}
 
 		// Calculate total time
@@ -98,6 +101,8 @@ func listSessions(cmd *cobra.Command, args []string) error {
 			statusStr = ui.DimStyle.Render(statusStr)
 		case session.StatusFailed:
 			statusStr = ui.ErrorStyle.Render(statusStr)
+		case session.StatusOrphaned:
+			statusStr = ui.WarningStyle.Render(statusStr)
 		}
 
 		// Show time in current status

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -96,6 +96,9 @@ func (s *tmuxSessionImpl) WorkspaceID() string {
 }
 
 func (s *tmuxSessionImpl) WorkspacePath() string {
+	if s.workspace == nil {
+		return ""
+	}
 	return s.workspace.Path
 }
 
@@ -129,6 +132,16 @@ func (s *tmuxSessionImpl) Start(ctx context.Context) error {
 
 	if s.info.StatusState.Status.IsRunning() {
 		return ErrSessionAlreadyRunning{ID: s.info.ID}
+	}
+
+	// Cannot start orphaned session
+	if s.info.StatusState.Status == StatusOrphaned {
+		return fmt.Errorf("cannot start orphaned session: %s", s.info.Error)
+	}
+
+	// Cannot start session without workspace
+	if s.workspace == nil {
+		return fmt.Errorf("cannot start session: workspace not available")
 	}
 
 	// Generate tmux session name

--- a/internal/core/session/types.go
+++ b/internal/core/session/types.go
@@ -64,9 +64,9 @@ func (s Status) IsRunning() bool {
 	return s == StatusWorking || s == StatusIdle
 }
 
-// IsTerminal returns true if the session is in a terminal state (completed, stopped or failed)
+// IsTerminal returns true if the session is in a terminal state (completed, stopped, failed or orphaned)
 func (s Status) IsTerminal() bool {
-	return s == StatusCompleted || s == StatusStopped || s == StatusFailed
+	return s == StatusCompleted || s == StatusStopped || s == StatusFailed || s == StatusOrphaned
 }
 
 const (
@@ -82,6 +82,8 @@ const (
 	StatusStopped Status = "stopped"
 	// StatusFailed indicates a session has failed or crashed
 	StatusFailed Status = "failed"
+	// StatusOrphaned indicates a session with missing dependencies (e.g., deleted workspace)
+	StatusOrphaned Status = "orphaned"
 )
 
 // StatusState holds runtime state for status tracking


### PR DESCRIPTION
## Summary

This PR fixes issue #187 by introducing a new `StatusOrphaned` status for sessions whose workspaces have been deleted.

## Problem

When running `amux ps` after deleting workspaces, users would see confusing warning messages:
```
time=2025-06-21T18:29:08.387+09:00 level=WARN msg="Failed to create session" error="workspace not found for session: workspace not found: workspace-release-v010-..."
```

## Solution

- Added new `StatusOrphaned` status to explicitly represent sessions with missing workspaces
- Sessions with deleted workspaces are marked as orphaned in `createSessionFromInfo`
- Orphaned sessions:
  - Display with warning color (yellow/orange) in session list
  - Show workspace name with "(deleted)" suffix
  - Cannot be started, returning clear error message
  - Are considered terminal state (IsTerminal() returns true)

## Implementation Details

1. **Status Addition**: Added `StatusOrphaned` to the Status constants
2. **Manager Logic**: When workspace is not found during session loading, mark as orphaned
3. **Display Logic**: Show orphaned status with appropriate styling and "(deleted)" suffix
4. **Start Prevention**: Orphaned sessions return error when attempting to start
5. **Nil Safety**: Handle nil workspace in WorkspacePath() method

## Test Plan

- [x] Added comprehensive test `TestManager_ListSessionsWithDeletedWorkspace`
- [x] All existing tests pass
- [x] Verified orphaned sessions cannot be started
- [ ] Manual testing with real sessions and deleted workspaces

## Why This Approach?

- **Clear Semantics**: `StatusOrphaned` explicitly represents the state (vs misusing `StatusFailed`)
- **Simple Implementation**: No API changes to Session interface, no complex error propagation
- **User-Friendly**: Clear visual indication and error messages
- **Future-Proof**: Easy to add cleanup commands or policies later

Fixes #187