### PR TITLE
feat: implement workspace semaphore for multi-agent coordination

### DIFF
--- a/internal/cli/commands/workspace/show.go
+++ b/internal/cli/commands/workspace/show.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +38,21 @@ func runShowWorkspace(cmd *cobra.Command, args []string) error {
 
 	// Print detailed workspace information
 	ui.PrintWorkspaceDetails(ws)
+
+	// Get and display semaphore information
+	holders, err := manager.GetSemaphoreHolders(ws.ID)
+	if err == nil && len(holders) > 0 {
+		ui.OutputLine("\n%s Active Sessions (%d):\n", ui.InfoIcon, len(holders))
+		for _, holder := range holders {
+			description := holder.Description
+			if description == "" {
+				description = fmt.Sprintf("Session %s", holder.SessionID)
+			}
+			ui.OutputLine("  - %s: %s (%s ago)", holder.ID, description, ui.FormatDuration(time.Since(holder.Timestamp)))
+		}
+	} else {
+		ui.OutputLine("\n%s Status: Available (no active sessions)", ui.SuccessIcon)
+	}
 
 	return nil
 }

--- a/internal/cli/commands/workspace/workspace.go
+++ b/internal/cli/commands/workspace/workspace.go
@@ -56,7 +56,7 @@ func init() {
 	pruneWorkspaceCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be removed without removing")
 
 	// Remove command flags
-	removeWorkspaceCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force removal without confirmation")
+	removeWorkspaceCmd.Flags().BoolVarP(&removeForce, "force", "f", false, "Force removal even if workspace is in use (stops all sessions)")
 	removeWorkspaceCmd.Flags().BoolVar(&removeNoHooks, "no-hooks", false, "Skip running hooks for this operation")
 }
 

--- a/internal/core/session/manager_semaphore.go
+++ b/internal/core/session/manager_semaphore.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aki/amux/internal/core/workspace"
+)
+
+// SessionStopperAdapter implements workspace.SessionStopper interface
+type SessionStopperAdapter struct {
+	manager *Manager
+}
+
+// NewSessionStopperAdapter creates a new adapter
+func NewSessionStopperAdapter(manager *Manager) *SessionStopperAdapter {
+	return &SessionStopperAdapter{manager: manager}
+}
+
+// StopSessionsInWorkspace stops all sessions in a workspace
+func (s *SessionStopperAdapter) StopSessionsInWorkspace(ctx context.Context, workspaceID string) error {
+	sessions, err := s.manager.ListByWorkspace(ctx, workspaceID)
+	if err != nil {
+		return fmt.Errorf("failed to list sessions: %w", err)
+	}
+
+	var errors []error
+	for _, sess := range sessions {
+		if err := sess.Stop(ctx); err != nil {
+			errors = append(errors, fmt.Errorf("failed to stop session %s: %w", sess.ID(), err))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to stop %d sessions", len(errors))
+	}
+
+	return nil
+}
+
+// ListSessionsInWorkspace lists all sessions in a workspace
+func (s *SessionStopperAdapter) ListSessionsInWorkspace(ctx context.Context, workspaceID string) ([]string, error) {
+	sessions, err := s.manager.ListByWorkspace(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, len(sessions))
+	for i, sess := range sessions {
+		ids[i] = string(sess.ID())
+	}
+
+	return ids, nil
+}
+
+// acquireSemaphore acquires a workspace semaphore for a session
+func (m *Manager) acquireSemaphore(ctx context.Context, info *Info) error {
+	if m.workspaceManager == nil {
+		// No workspace manager, skip semaphore
+		return nil
+	}
+
+	holder := workspace.Holder{
+		ID:          info.ID,
+		Type:        workspace.HolderTypeSession,
+		SessionID:   info.ID,
+		WorkspaceID: info.WorkspaceID,
+		Timestamp:   time.Now(),
+		Description: fmt.Sprintf("%s: %s", info.AgentID, info.Description),
+	}
+
+	if holder.Description == info.AgentID+":" || holder.Description == info.AgentID+": " {
+		// Use command if no description
+		holder.Description = fmt.Sprintf("%s: %s", info.AgentID, info.Command)
+	}
+
+	return m.workspaceManager.AcquireSemaphore(info.WorkspaceID, holder)
+}
+
+// releaseSemaphore releases a workspace semaphore for a session
+func (m *Manager) releaseSemaphore(ctx context.Context, sessionID, workspaceID string) error {
+	if m.workspaceManager == nil {
+		// No workspace manager, skip semaphore
+		return nil
+	}
+
+	return m.workspaceManager.ReleaseSemaphore(workspaceID, sessionID)
+}

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -266,6 +266,12 @@ func (s *tmuxSessionImpl) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to save session: %w", err)
 	}
 
+	// Release workspace semaphore
+	if err := s.manager.releaseSemaphore(ctx, s.info.ID, s.info.WorkspaceID); err != nil {
+		// Log error but don't fail the stop operation
+		s.logger.Warn("failed to release workspace semaphore", "error", err, "session_id", s.info.ID)
+	}
+
 	return nil
 }
 

--- a/internal/core/session/workspace_integration.go
+++ b/internal/core/session/workspace_integration.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"context"
+
+	"github.com/aki/amux/internal/core/workspace"
+)
+
+// WorkspaceSessionChecker adapts session.Manager to workspace.SessionChecker interface
+type WorkspaceSessionChecker struct {
+	sessionManager *Manager
+}
+
+// NewWorkspaceSessionChecker creates a new adapter for session checking
+func NewWorkspaceSessionChecker(sessionManager *Manager) workspace.SessionChecker {
+	return &WorkspaceSessionChecker{
+		sessionManager: sessionManager,
+	}
+}
+
+// IsSessionActive checks if a session exists and is active
+func (w *WorkspaceSessionChecker) IsSessionActive(sessionID string) (bool, error) {
+	sess, err := w.sessionManager.Get(context.Background(), ID(sessionID))
+	if err != nil {
+		// Session not found = not active
+		return false, nil
+	}
+
+	// Check if session is in a running state
+	status := sess.Status()
+	return status.IsRunning(), nil
+}

--- a/internal/core/workspace/holder.go
+++ b/internal/core/workspace/holder.go
@@ -1,0 +1,40 @@
+package workspace
+
+import (
+	"time"
+)
+
+// HolderType represents the type of entity holding a semaphore
+type HolderType string
+
+const (
+	// HolderTypeSession represents a session holding the semaphore
+	HolderTypeSession HolderType = "session"
+	// HolderTypeCLI represents a CLI command holding the semaphore
+	HolderTypeCLI HolderType = "cli"
+)
+
+// Holder represents an entity holding a workspace semaphore
+type Holder struct {
+	ID          string     `json:"id"`           // Unique holder ID (usually session ID)
+	Type        HolderType `json:"type"`         // Type of holder
+	SessionID   string     `json:"session_id"`   // Associated session ID (if applicable)
+	WorkspaceID string     `json:"workspace_id"` // Workspace being held
+	Timestamp   time.Time  `json:"timestamp"`    // When the semaphore was acquired
+	Description string     `json:"description"`  // Human-readable description
+}
+
+// IsExpired checks if a holder has expired based on its type
+func (h *Holder) IsExpired() bool {
+	switch h.Type {
+	case HolderTypeCLI:
+		// CLI commands have a 5-minute timeout
+		return time.Since(h.Timestamp) > 5*time.Minute
+	case HolderTypeSession:
+		// Sessions don't expire based on time alone
+		return false
+	default:
+		// Unknown types are considered expired
+		return true
+	}
+}

--- a/internal/core/workspace/manager.go
+++ b/internal/core/workspace/manager.go
@@ -25,6 +25,7 @@ type Manager struct {
 	workspacesDir string
 	idMapper      *idmap.IDMapper
 	fm            *filemanager.Manager[Workspace]
+	semaphore     *SemaphoreComponents // Semaphore-related components
 }
 
 // NewManager creates a new workspace manager

--- a/internal/core/workspace/manager_semaphore.go
+++ b/internal/core/workspace/manager_semaphore.go
@@ -1,0 +1,143 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// RemoveOptions contains options for removing a workspace
+type RemoveOptions struct {
+	Force bool // Force removal even if workspace is in use
+}
+
+// SessionStopper is an interface for stopping sessions
+type SessionStopper interface {
+	StopSessionsInWorkspace(ctx context.Context, workspaceID string) error
+	ListSessionsInWorkspace(ctx context.Context, workspaceID string) ([]string, error)
+}
+
+// SemaphoreComponents holds semaphore-related components
+type SemaphoreComponents struct {
+	SemaphoreManager *SemaphoreManager
+	Reconciler       *SemaphoreReconciler
+	SessionStopper   SessionStopper
+}
+
+// InitializeSemaphore sets up semaphore components for the workspace manager
+func (m *Manager) InitializeSemaphore(sessionChecker SessionChecker, sessionStopper SessionStopper, logger *slog.Logger) {
+	// Create semaphore manager
+	semaphoreManager := NewSemaphoreManager(m.workspacesDir, sessionChecker)
+
+	// Create reconciler
+	reconciler := NewSemaphoreReconciler(semaphoreManager, sessionChecker, logger)
+	semaphoreManager.SetReconciler(reconciler)
+
+	// Store components
+	m.semaphore = &SemaphoreComponents{
+		SemaphoreManager: semaphoreManager,
+		Reconciler:       reconciler,
+		SessionStopper:   sessionStopper,
+	}
+}
+
+// AcquireSemaphore acquires a semaphore for a workspace
+func (m *Manager) AcquireSemaphore(workspaceID string, holder Holder) error {
+	if m.semaphore == nil || m.semaphore.SemaphoreManager == nil {
+		// Semaphore not initialized, skip
+		return nil
+	}
+
+	return m.semaphore.SemaphoreManager.Acquire(workspaceID, holder)
+}
+
+// ReleaseSemaphore releases a semaphore for a workspace
+func (m *Manager) ReleaseSemaphore(workspaceID string, holderID string) error {
+	if m.semaphore == nil || m.semaphore.SemaphoreManager == nil {
+		// Semaphore not initialized, skip
+		return nil
+	}
+
+	return m.semaphore.SemaphoreManager.Release(workspaceID, holderID)
+}
+
+// GetSemaphoreHolders returns all holders for a workspace
+func (m *Manager) GetSemaphoreHolders(workspaceID string) ([]Holder, error) {
+	if m.semaphore == nil || m.semaphore.SemaphoreManager == nil {
+		// Semaphore not initialized, return empty
+		return []Holder{}, nil
+	}
+
+	return m.semaphore.SemaphoreManager.GetHolders(workspaceID)
+}
+
+// IsWorkspaceInUse checks if a workspace is in use by any holders
+func (m *Manager) IsWorkspaceInUse(workspaceID string) (bool, []Holder, error) {
+	if m.semaphore == nil || m.semaphore.SemaphoreManager == nil {
+		// Semaphore not initialized, assume not in use
+		return false, []Holder{}, nil
+	}
+
+	// Reconcile before checking
+	if m.semaphore.Reconciler != nil {
+		_ = m.semaphore.Reconciler.ReconcileWorkspace(workspaceID)
+	}
+
+	return m.semaphore.SemaphoreManager.IsInUse(workspaceID)
+}
+
+// RemoveWithOptions removes a workspace with additional options
+func (m *Manager) RemoveWithOptions(ctx context.Context, identifier Identifier, opts RemoveOptions) error {
+	workspace, err := m.ResolveWorkspace(ctx, identifier)
+	if err != nil {
+		return err
+	}
+
+	// Check semaphore if not forcing
+	if !opts.Force && m.semaphore != nil {
+		inUse, holders, err := m.IsWorkspaceInUse(workspace.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check workspace usage: %w", err)
+		}
+
+		if inUse {
+			return &ErrWorkspaceInUse{
+				WorkspaceID: workspace.ID,
+				Holders:     holders,
+			}
+		}
+	}
+
+	// If forcing, stop all sessions first
+	if opts.Force && m.semaphore != nil && m.semaphore.SessionStopper != nil {
+		if err := m.semaphore.SessionStopper.StopSessionsInWorkspace(ctx, workspace.ID); err != nil {
+			return fmt.Errorf("failed to stop sessions: %w", err)
+		}
+	}
+
+	// Call the original Remove method
+	return m.Remove(ctx, identifier)
+}
+
+// ErrWorkspaceInUse is returned when trying to remove a workspace that is in use
+type ErrWorkspaceInUse struct {
+	WorkspaceID string
+	Holders     []Holder
+}
+
+func (e *ErrWorkspaceInUse) Error() string {
+	return fmt.Sprintf("workspace %s is currently in use by %d holder(s)", e.WorkspaceID, len(e.Holders))
+}
+
+// GetHolderDetails returns formatted details about holders
+func (e *ErrWorkspaceInUse) GetHolderDetails() []string {
+	details := make([]string, len(e.Holders))
+	for i, h := range e.Holders {
+		desc := h.Description
+		if desc == "" {
+			desc = string(h.Type)
+		}
+		details[i] = fmt.Sprintf("%s (%s)", h.ID, desc)
+	}
+	return details
+}

--- a/internal/core/workspace/reconciler.go
+++ b/internal/core/workspace/reconciler.go
@@ -1,0 +1,128 @@
+package workspace
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// SemaphoreReconciler handles cleanup of stale semaphore entries
+type SemaphoreReconciler struct {
+	semaphoreManager *SemaphoreManager
+	sessionChecker   SessionChecker
+	logger           *slog.Logger
+}
+
+// NewSemaphoreReconciler creates a new semaphore reconciler
+func NewSemaphoreReconciler(semaphoreManager *SemaphoreManager, sessionChecker SessionChecker, logger *slog.Logger) *SemaphoreReconciler {
+	return &SemaphoreReconciler{
+		semaphoreManager: semaphoreManager,
+		sessionChecker:   sessionChecker,
+		logger:           logger,
+	}
+}
+
+// ReconcileWorkspace cleans up stale holders for a specific workspace
+func (r *SemaphoreReconciler) ReconcileWorkspace(workspaceID string) error {
+	return r.semaphoreManager.updateSemaphore(workspaceID, func(data *SemaphoreData) error {
+		validHolders := make([]Holder, 0, len(data.Holders))
+		removedCount := 0
+
+		for _, holder := range data.Holders {
+			if r.isHolderValid(holder) {
+				validHolders = append(validHolders, holder)
+			} else {
+				removedCount++
+				r.logger.Debug("removing stale semaphore holder",
+					"workspace_id", workspaceID,
+					"holder_id", holder.ID,
+					"holder_type", holder.Type,
+					"session_id", holder.SessionID,
+				)
+			}
+		}
+
+		data.Holders = validHolders
+
+		if removedCount > 0 {
+			r.logger.Info("reconciled workspace semaphore",
+				"workspace_id", workspaceID,
+				"removed_count", removedCount,
+				"remaining_count", len(validHolders),
+			)
+		}
+
+		return nil
+	})
+}
+
+// ReconcileAll reconciles semaphores for all workspaces
+func (r *SemaphoreReconciler) ReconcileAll(workspaceIDs []string) error {
+	var reconcileErrors []error
+	successCount := 0
+
+	for _, wsID := range workspaceIDs {
+		if err := r.ReconcileWorkspace(wsID); err != nil {
+			reconcileErrors = append(reconcileErrors, fmt.Errorf("workspace %s: %w", wsID, err))
+			r.logger.Error("failed to reconcile workspace semaphore",
+				"workspace_id", wsID,
+				"error", err,
+			)
+		} else {
+			successCount++
+		}
+	}
+
+	if len(reconcileErrors) > 0 {
+		return fmt.Errorf("reconciliation completed with %d errors (succeeded: %d)", len(reconcileErrors), successCount)
+	}
+
+	return nil
+}
+
+// isHolderValid checks if a holder is still valid
+func (r *SemaphoreReconciler) isHolderValid(holder Holder) bool {
+	// Check if holder has expired based on type
+	if holder.IsExpired() {
+		return false
+	}
+
+	switch holder.Type {
+	case HolderTypeSession:
+		// Check if session exists and is active
+		active, err := r.sessionChecker.IsSessionActive(holder.SessionID)
+		if err != nil {
+			// If we can't check, assume it's invalid to be safe
+			r.logger.Warn("failed to check session status",
+				"session_id", holder.SessionID,
+				"error", err,
+			)
+			return false
+		}
+		return active
+
+	case HolderTypeCLI:
+		// CLI holders are valid if not expired (already checked above)
+		return true
+
+	default:
+		// Unknown holder types are invalid
+		r.logger.Warn("unknown holder type",
+			"holder_type", holder.Type,
+			"holder_id", holder.ID,
+		)
+		return false
+	}
+}
+
+// ReconcileOnAcquire reconciles before acquiring a new semaphore
+func (r *SemaphoreReconciler) ReconcileOnAcquire(workspaceID string) error {
+	// Perform reconciliation but don't fail the acquire if reconciliation fails
+	if err := r.ReconcileWorkspace(workspaceID); err != nil {
+		r.logger.Warn("reconciliation failed during acquire",
+			"workspace_id", workspaceID,
+			"error", err,
+		)
+		// Continue with acquire even if reconciliation fails
+	}
+	return nil
+}

--- a/internal/core/workspace/reconciler_test.go
+++ b/internal/core/workspace/reconciler_test.go
@@ -1,0 +1,205 @@
+package workspace
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemaphoreReconciler_ReconcileWorkspace(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	checker := &mockSessionChecker{
+		activeSessions: map[string]bool{
+			"session-1": true,
+			"session-2": false, // Inactive
+			// session-3 doesn't exist
+		},
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+	reconciler := NewSemaphoreReconciler(sm, checker, logger)
+	// Don't set reconciler yet to avoid auto-reconciliation during setup
+
+	workspaceID := "ws-reconcile-test"
+
+	// Add various holders
+	holders := []Holder{
+		{ID: "session-1", Type: HolderTypeSession, SessionID: "session-1", Description: "Active session"},
+		{ID: "session-2", Type: HolderTypeSession, SessionID: "session-2", Description: "Inactive session"},
+		{ID: "session-3", Type: HolderTypeSession, SessionID: "session-3", Description: "Non-existent session"},
+		{ID: "cli-1", Type: HolderTypeCLI, Timestamp: time.Now().Add(-2 * time.Minute), Description: "Recent CLI"},
+		{ID: "cli-2", Type: HolderTypeCLI, Timestamp: time.Now().Add(-10 * time.Minute), Description: "Expired CLI"},
+		{ID: "unknown-1", Type: "unknown", Description: "Unknown type"},
+	}
+
+	for _, h := range holders {
+		// Set timestamp for holders that need it
+		if h.Timestamp.IsZero() && h.Type != HolderTypeCLI {
+			h.Timestamp = time.Now()
+		}
+		err := sm.Acquire(workspaceID, h)
+		require.NoError(t, err)
+	}
+
+	// Verify all holders were added
+	beforeHolders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, beforeHolders, 6)
+
+	// Reconcile
+	err = reconciler.ReconcileWorkspace(workspaceID)
+	require.NoError(t, err)
+
+	// Verify only valid holders remain
+	afterHolders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, afterHolders, 2) // Only session-1 and cli-1 should remain
+
+	// Check specific holders
+	holderIDs := make(map[string]bool)
+	for _, h := range afterHolders {
+		holderIDs[h.ID] = true
+	}
+	assert.True(t, holderIDs["session-1"], "Active session should remain")
+	assert.True(t, holderIDs["cli-1"], "Recent CLI should remain")
+	assert.False(t, holderIDs["session-2"], "Inactive session should be removed")
+	assert.False(t, holderIDs["session-3"], "Non-existent session should be removed")
+	assert.False(t, holderIDs["cli-2"], "Expired CLI should be removed")
+	assert.False(t, holderIDs["unknown-1"], "Unknown type should be removed")
+}
+
+func TestSemaphoreReconciler_ReconcileAll(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	checker := &mockSessionChecker{
+		activeSessions: map[string]bool{
+			"session-1": true,
+		},
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+	reconciler := NewSemaphoreReconciler(sm, checker, logger)
+
+	// Create multiple workspaces with holders
+	workspaceIDs := []string{"ws-1", "ws-2", "ws-3"}
+
+	for _, wsID := range workspaceIDs {
+		// Add a mix of valid and invalid holders
+		holders := []Holder{
+			{ID: "session-1", Type: HolderTypeSession, SessionID: "session-1"},
+			{ID: "session-dead", Type: HolderTypeSession, SessionID: "session-dead"},
+			{ID: "cli-old", Type: HolderTypeCLI, Timestamp: time.Now().Add(-1 * time.Hour)},
+		}
+
+		for _, h := range holders {
+			if h.Timestamp.IsZero() && h.Type != HolderTypeCLI {
+				h.Timestamp = time.Now()
+			}
+			err := sm.Acquire(wsID, h)
+			require.NoError(t, err)
+		}
+	}
+
+	// Reconcile all
+	err := reconciler.ReconcileAll(workspaceIDs)
+	require.NoError(t, err)
+
+	// Verify each workspace has only valid holders
+	for _, wsID := range workspaceIDs {
+		holders, err := sm.GetHolders(wsID)
+		require.NoError(t, err)
+		assert.Len(t, holders, 1, "Each workspace should have only 1 valid holder")
+		assert.Equal(t, "session-1", holders[0].ID)
+	}
+}
+
+func TestSemaphoreReconciler_ReconcileOnAcquire(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	checker := &mockSessionChecker{
+		activeSessions: map[string]bool{
+			"session-new": true,
+		},
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+	reconciler := NewSemaphoreReconciler(sm, checker, logger)
+	sm.SetReconciler(reconciler)
+
+	workspaceID := "ws-acquire-test"
+
+	// Add an expired holder directly (bypassing reconciliation)
+	sm.updateSemaphore(workspaceID, func(data *SemaphoreData) error {
+		data.Holders = append(data.Holders, Holder{
+			ID:        "cli-old",
+			Type:      HolderTypeCLI,
+			Timestamp: time.Now().Add(-1 * time.Hour),
+		})
+		return nil
+	})
+
+	// Verify expired holder exists
+	holders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, holders, 1)
+
+	// Acquire new holder (should trigger reconciliation)
+	newHolder := Holder{
+		ID:        "session-new",
+		Type:      HolderTypeSession,
+		SessionID: "session-new",
+	}
+	err = sm.Acquire(workspaceID, newHolder)
+	require.NoError(t, err)
+
+	// Verify old holder was removed and new holder added
+	holders, err = sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, holders, 1)
+	assert.Equal(t, "session-new", holders[0].ID)
+}
+
+func TestReconciler_ErrorHandling(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Create a reconciler with nil session checker to cause errors
+	sm := NewSemaphoreManager(basePath, nil)
+	reconciler := NewSemaphoreReconciler(sm, nil, logger)
+
+	// Try to reconcile non-existent workspace
+	err := reconciler.ReconcileWorkspace("non-existent")
+	// Should not error on non-existent workspace
+	assert.NoError(t, err)
+
+	// ReconcileAll with some failing workspaces
+	workspaceIDs := []string{"ws-1", "ws-2", "ws-3"}
+
+	// Create one workspace with a problematic path
+	problemPath := filepath.Join(basePath, "ws-2")
+	err = os.MkdirAll(problemPath, 0o755)
+	require.NoError(t, err)
+
+	// Make the semaphore file unreadable
+	semaphorePath := filepath.Join(problemPath, semaphoreFileName)
+	err = os.WriteFile(semaphorePath, []byte("data"), 0o000)
+	require.NoError(t, err)
+
+	// Reconcile all - should report errors but not panic
+	err = reconciler.ReconcileAll(workspaceIDs)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation completed with")
+}

--- a/internal/core/workspace/semaphore.go
+++ b/internal/core/workspace/semaphore.go
@@ -1,0 +1,213 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const (
+	semaphoreVersion  = "1.0"
+	semaphoreFileName = ".semaphore"
+	lockFileName      = ".semaphore.lock"
+)
+
+// SemaphoreData represents the semaphore file contents
+type SemaphoreData struct {
+	Version string   `json:"version"`
+	Holders []Holder `json:"holders"`
+}
+
+// SessionChecker is an interface for checking session status
+type SessionChecker interface {
+	// IsSessionActive checks if a session exists and is active
+	IsSessionActive(sessionID string) (bool, error)
+}
+
+// SemaphoreManager manages workspace semaphores
+type SemaphoreManager struct {
+	basePath       string
+	sessionChecker SessionChecker
+	reconciler     *SemaphoreReconciler
+}
+
+// NewSemaphoreManager creates a new semaphore manager
+func NewSemaphoreManager(basePath string, sessionChecker SessionChecker) *SemaphoreManager {
+	sm := &SemaphoreManager{
+		basePath:       basePath,
+		sessionChecker: sessionChecker,
+	}
+	// Create reconciler after manager is initialized
+	// This will be set via SetReconciler to avoid circular dependency
+	return sm
+}
+
+// SetReconciler sets the reconciler for the semaphore manager
+func (s *SemaphoreManager) SetReconciler(reconciler *SemaphoreReconciler) {
+	s.reconciler = reconciler
+}
+
+// Acquire acquires a semaphore for a workspace
+func (s *SemaphoreManager) Acquire(workspaceID string, holder Holder) error {
+	// Reconcile before acquiring
+	if s.reconciler != nil {
+		_ = s.reconciler.ReconcileOnAcquire(workspaceID)
+	}
+
+	return s.updateSemaphore(workspaceID, func(data *SemaphoreData) error {
+		// Set timestamp if not already set
+		if holder.Timestamp.IsZero() {
+			holder.Timestamp = time.Now()
+		}
+
+		// Ensure workspace ID matches
+		holder.WorkspaceID = workspaceID
+
+		// Add the new holder
+		data.Holders = append(data.Holders, holder)
+		return nil
+	})
+}
+
+// Release releases a semaphore for a specific holder
+func (s *SemaphoreManager) Release(workspaceID, holderID string) error {
+	return s.updateSemaphore(workspaceID, func(data *SemaphoreData) error {
+		// Filter out the holder with matching ID
+		filtered := make([]Holder, 0, len(data.Holders))
+		for _, h := range data.Holders {
+			if h.ID != holderID {
+				filtered = append(filtered, h)
+			}
+		}
+		data.Holders = filtered
+		return nil
+	})
+}
+
+// GetHolders returns all holders for a workspace
+func (s *SemaphoreManager) GetHolders(workspaceID string) ([]Holder, error) {
+	data, err := s.readSemaphoreData(workspaceID)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No semaphore file means no holders
+			return []Holder{}, nil
+		}
+		return nil, err
+	}
+	return data.Holders, nil
+}
+
+// IsInUse checks if a workspace is in use by any holders
+func (s *SemaphoreManager) IsInUse(workspaceID string) (bool, []Holder, error) {
+	holders, err := s.GetHolders(workspaceID)
+	if err != nil {
+		return false, nil, err
+	}
+	return len(holders) > 0, holders, nil
+}
+
+// updateSemaphore performs an atomic update on the semaphore file
+func (s *SemaphoreManager) updateSemaphore(workspaceID string, updater func(*SemaphoreData) error) error {
+	lockPath := s.getLockPath(workspaceID)
+	semaphorePath := s.getSemaphorePath(workspaceID)
+	tempPath := semaphorePath + ".tmp"
+
+	// Ensure directory exists
+	dir := filepath.Dir(semaphorePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create semaphore directory: %w", err)
+	}
+
+	// Acquire file lock
+	lock := flock.New(lockPath)
+
+	// Use Lock() instead of TryLock() to wait for lock
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+
+	// Read current data
+	data, err := s.readSemaphoreDataLocked(semaphorePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// If file doesn't exist, create new data
+	if data == nil {
+		data = &SemaphoreData{
+			Version: semaphoreVersion,
+			Holders: []Holder{},
+		}
+	}
+
+	// Apply the update
+	if err := updater(data); err != nil {
+		return err
+	}
+
+	// Write to temporary file
+	if err := s.writeToFile(tempPath, data); err != nil {
+		return err
+	}
+
+	// Atomic rename
+	if err := os.Rename(tempPath, semaphorePath); err != nil {
+		// Clean up temp file on error
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("failed to update semaphore file: %w", err)
+	}
+
+	return nil
+}
+
+// readSemaphoreData reads semaphore data without locking
+func (s *SemaphoreManager) readSemaphoreData(workspaceID string) (*SemaphoreData, error) {
+	semaphorePath := s.getSemaphorePath(workspaceID)
+	return s.readSemaphoreDataLocked(semaphorePath)
+}
+
+// readSemaphoreDataLocked reads semaphore data (assumes lock is held)
+func (s *SemaphoreManager) readSemaphoreDataLocked(semaphorePath string) (*SemaphoreData, error) {
+	content, err := os.ReadFile(semaphorePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var data SemaphoreData
+	if err := json.Unmarshal(content, &data); err != nil {
+		return nil, fmt.Errorf("failed to parse semaphore file: %w", err)
+	}
+
+	return &data, nil
+}
+
+// writeToFile writes semaphore data to a file
+func (s *SemaphoreManager) writeToFile(path string, data *SemaphoreData) error {
+	content, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal semaphore data: %w", err)
+	}
+
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write semaphore file: %w", err)
+	}
+
+	return nil
+}
+
+// getSemaphorePath returns the path to the semaphore file
+func (s *SemaphoreManager) getSemaphorePath(workspaceID string) string {
+	return filepath.Join(s.basePath, workspaceID, semaphoreFileName)
+}
+
+// getLockPath returns the path to the lock file
+func (s *SemaphoreManager) getLockPath(workspaceID string) string {
+	return filepath.Join(s.basePath, workspaceID, lockFileName)
+}

--- a/internal/core/workspace/semaphore_test.go
+++ b/internal/core/workspace/semaphore_test.go
@@ -1,0 +1,253 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSessionChecker implements SessionChecker for testing
+type mockSessionChecker struct {
+	activeSessions map[string]bool
+}
+
+func (m *mockSessionChecker) IsSessionActive(sessionID string) (bool, error) {
+	active, exists := m.activeSessions[sessionID]
+	return exists && active, nil
+}
+
+func TestSemaphoreManager_AcquireRelease(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+
+	checker := &mockSessionChecker{
+		activeSessions: map[string]bool{
+			"session-1": true,
+		},
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+
+	workspaceID := "ws-test-123"
+	holder := Holder{
+		ID:          "session-1",
+		Type:        HolderTypeSession,
+		SessionID:   "session-1",
+		Description: "Test session",
+	}
+
+	// Test acquire
+	err := sm.Acquire(workspaceID, holder)
+	require.NoError(t, err)
+
+	// Verify holder was added
+	holders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, holders, 1)
+	assert.Equal(t, "session-1", holders[0].ID)
+	assert.Equal(t, workspaceID, holders[0].WorkspaceID)
+	assert.False(t, holders[0].Timestamp.IsZero())
+
+	// Test release
+	err = sm.Release(workspaceID, "session-1")
+	require.NoError(t, err)
+
+	// Verify holder was removed
+	holders, err = sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Empty(t, holders)
+}
+
+func TestSemaphoreManager_MultipleHolders(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+
+	checker := &mockSessionChecker{
+		activeSessions: map[string]bool{
+			"session-1": true,
+			"session-2": true,
+		},
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+	workspaceID := "ws-test-123"
+
+	// Add multiple holders
+	holders := []Holder{
+		{ID: "session-1", Type: HolderTypeSession, SessionID: "session-1"},
+		{ID: "session-2", Type: HolderTypeSession, SessionID: "session-2"},
+		{ID: "cli-1", Type: HolderTypeCLI, Description: "CLI command"},
+	}
+
+	for _, h := range holders {
+		err := sm.Acquire(workspaceID, h)
+		require.NoError(t, err)
+	}
+
+	// Verify all holders
+	gotHolders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, gotHolders, 3)
+
+	// Test IsInUse
+	inUse, usageHolders, err := sm.IsInUse(workspaceID)
+	require.NoError(t, err)
+	assert.True(t, inUse)
+	assert.Len(t, usageHolders, 3)
+
+	// Release one holder
+	err = sm.Release(workspaceID, "session-1")
+	require.NoError(t, err)
+
+	// Verify remaining holders
+	gotHolders, err = sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, gotHolders, 2)
+}
+
+func TestSemaphoreManager_ConcurrentAccess(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+
+	checker := &mockSessionChecker{
+		activeSessions: make(map[string]bool),
+	}
+
+	sm := NewSemaphoreManager(basePath, checker)
+	workspaceID := "ws-concurrent-test"
+
+	// Run concurrent operations
+	done := make(chan bool)
+	errors := make(chan error, 20)
+
+	// Start 10 goroutines acquiring semaphores
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			holder := Holder{
+				ID:        string(rune('a' + id)),
+				Type:      HolderTypeSession,
+				SessionID: string(rune('a' + id)),
+			}
+			if err := sm.Acquire(workspaceID, holder); err != nil {
+				errors <- err
+			}
+			done <- true
+		}(i)
+	}
+
+	// Start 10 goroutines reading holders
+	for i := 0; i < 10; i++ {
+		go func() {
+			if _, err := sm.GetHolders(workspaceID); err != nil {
+				errors <- err
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all operations to complete
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+	close(errors)
+
+	// Check for errors
+	for err := range errors {
+		t.Errorf("Concurrent operation failed: %v", err)
+	}
+
+	// Verify final state
+	holders, err := sm.GetHolders(workspaceID)
+	require.NoError(t, err)
+	assert.Len(t, holders, 10)
+}
+
+func TestSemaphoreManager_NonExistentWorkspace(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+
+	sm := NewSemaphoreManager(basePath, nil)
+
+	// Get holders for non-existent workspace
+	holders, err := sm.GetHolders("non-existent")
+	require.NoError(t, err)
+	assert.Empty(t, holders)
+
+	// Check if non-existent workspace is in use
+	inUse, _, err := sm.IsInUse("non-existent")
+	require.NoError(t, err)
+	assert.False(t, inUse)
+}
+
+func TestSemaphoreManager_CorruptedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "workspaces")
+	workspaceID := "ws-corrupted"
+
+	// Create directory and corrupted semaphore file
+	wsDir := filepath.Join(basePath, workspaceID)
+	err := os.MkdirAll(wsDir, 0o755)
+	require.NoError(t, err)
+
+	semaphorePath := filepath.Join(wsDir, semaphoreFileName)
+	err = os.WriteFile(semaphorePath, []byte("invalid json"), 0o644)
+	require.NoError(t, err)
+
+	sm := NewSemaphoreManager(basePath, nil)
+
+	// Try to get holders - should fail
+	_, err = sm.GetHolders(workspaceID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse semaphore file")
+}
+
+func TestHolder_IsExpired(t *testing.T) {
+	tests := []struct {
+		name     string
+		holder   Holder
+		expected bool
+	}{
+		{
+			name: "session holder not expired",
+			holder: Holder{
+				Type:      HolderTypeSession,
+				Timestamp: time.Now(),
+			},
+			expected: false,
+		},
+		{
+			name: "cli holder not expired",
+			holder: Holder{
+				Type:      HolderTypeCLI,
+				Timestamp: time.Now().Add(-2 * time.Minute),
+			},
+			expected: false,
+		},
+		{
+			name: "cli holder expired",
+			holder: Holder{
+				Type:      HolderTypeCLI,
+				Timestamp: time.Now().Add(-10 * time.Minute),
+			},
+			expected: true,
+		},
+		{
+			name: "unknown type expired",
+			holder: Holder{
+				Type:      "unknown",
+				Timestamp: time.Now(),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.holder.IsExpired())
+		})
+	}
+}

--- a/internal/mcp/session_resources.go
+++ b/internal/mcp/session_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -312,6 +313,15 @@ func (s *ServerV2) createSessionManager() (*session.Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session manager: %w", err)
 	}
+
+	// Initialize semaphore support
+	// Create adapters
+	sessionChecker := session.NewWorkspaceSessionChecker(manager)
+	sessionStopper := session.NewSessionStopperAdapter(manager)
+
+	// Initialize with default logger (could be enhanced to use configurable logger)
+	logger := slog.Default()
+	workspaceManager.InitializeSemaphore(sessionChecker, sessionStopper, logger)
 
 	return manager, nil
 }


### PR DESCRIPTION
## Summary
- Implements workspace semaphore functionality to prevent accidental deletion of workspaces in use (#86)
- Adds automatic session cleanup when workspace is deleted with --force flag (#188)
- Enhances `ws list` and `ws show` commands to display workspace usage status

## Changes

### Core Semaphore Implementation
- Added file-based semaphore system using `.amux/workspaces/{id}/.semaphore`
- Implemented atomic file operations with flock for thread safety
- Added reconciliation logic to clean up stale semaphore entries
- Integrated semaphore lifecycle with session creation/termination

### User Interface Enhancements
- `ws list` now shows "Available" or "In use (n)" in SESSIONS column
- `ws show` displays active sessions with details when workspace is occupied
- `ws remove` shows which sessions are using the workspace before deletion
- Added `--force` flag to `ws remove` for stopping sessions and forcing removal

### Technical Details
- Session-based semaphore acquisition (not process-based)
- CLI holder expiration after 5 minutes
- Adapter pattern to avoid circular dependencies between packages
- Comprehensive test coverage including concurrent access scenarios

## Test Plan
- [x] Unit tests for semaphore operations
- [x] Integration tests for session lifecycle
- [x] Manual testing of CLI commands
- [ ] Test concurrent agent scenarios
- [ ] Verify reconciliation handles edge cases

## Related Issues
Fixes #86
Fixes #188