### PR TITLE
fix: use git describe for version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
           # Create output directory
           mkdir -p dist
 
-          # Extract version from tag
-          VERSION=${GITHUB_REF#refs/tags/v}
+          # Extract version using git describe
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
 
           # Build for multiple platforms and create tar.gz archives
           GOOS=linux GOARCH=amd64 just build


### PR DESCRIPTION
## Summary
- Replace manual version extraction with `git describe` for consistent versioning
- Fix release workflow failures when triggered from main branch pushes
- Maintain existing asset naming convention without 'v' prefix

## Problem
The release workflow was failing on main branch builds because `VERSION=${GITHUB_REF#refs/tags/v}` would result in `VERSION=refs/heads/main`, causing invalid tar.gz filenames.

## Solution
Use `git describe --tags --always --dirty` which provides:
- Exact tag version for tagged releases (e.g., `v0.1.0` → `0.1.0`)
- Descriptive version for main branch builds (e.g., `v0.1.0-15-g810e0c1` → `0.1.0-15-g810e0c1`)
- Fallback to "dev" if no tags exist

## Test plan
- [x] Verify git describe output format
- [x] Confirm existing release asset naming convention
- [ ] CI should pass on this PR
- [ ] Draft release should be created with proper version naming