### PR TITLE
fix: prevent agent name from being executed as command in tmux session

### DIFF
--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -10,6 +10,9 @@ import (
 const (
 	// DefaultShell is the fallback shell used when no command or shell is configured
 	DefaultShell = "bash"
+
+	// DefaultAgentID is the default agent identifier when none is specified
+	DefaultAgentID = "default"
 )
 
 // Manager manages agent configurations

--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -7,6 +7,11 @@ import (
 	"github.com/aki/amux/internal/core/config"
 )
 
+const (
+	// DefaultShell is the fallback shell used when no command or shell is configured
+	DefaultShell = "bash"
+)
+
 // Manager manages agent configurations
 type Manager struct {
 	configManager *config.Manager
@@ -126,8 +131,8 @@ func (m *Manager) GetDefaultCommand(agentID string) (string, error) {
 		if params.Shell != "" {
 			return params.Shell, nil
 		}
-		// Fall back to bash as the default shell
-		return "bash", nil
+		// Fall back to the default shell
+		return DefaultShell, nil
 	case config.AgentTypeClaudeCode, config.AgentTypeAPI:
 		// Future: handle other types
 		return "", fmt.Errorf("agent type %q not yet supported", agent.Type)

--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -120,7 +120,7 @@ func (m *Manager) GetDefaultCommand(agentID string) (string, error) {
 			return "", fmt.Errorf("failed to get tmux params: %w", err)
 		}
 		if params.Command == "" {
-			return "", fmt.Errorf("no command configured for agent %q", agentID)
+			return "", fmt.Errorf("no command configured for agent %q (type: %s)", agentID, agent.Type)
 		}
 		return params.Command, nil
 	case config.AgentTypeClaudeCode, config.AgentTypeAPI:

--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -119,10 +119,15 @@ func (m *Manager) GetDefaultCommand(agentID string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("failed to get tmux params: %w", err)
 		}
-		if params.Command == "" {
-			return "", fmt.Errorf("no command configured for agent %q (type: %s)", agentID, agent.Type)
+		if params.Command != "" {
+			return params.Command, nil
 		}
-		return params.Command, nil
+		// If no command is specified, use the shell if configured
+		if params.Shell != "" {
+			return params.Shell, nil
+		}
+		// Fall back to bash as the default shell
+		return "bash", nil
 	case config.AgentTypeClaudeCode, config.AgentTypeAPI:
 		// Future: handle other types
 		return "", fmt.Errorf("agent type %q not yet supported", agent.Type)

--- a/internal/core/agent/manager.go
+++ b/internal/core/agent/manager.go
@@ -130,6 +130,9 @@ func (m *Manager) GetDefaultCommand(agentID string) (string, error) {
 		if params.Command != "" {
 			return params.Command, nil
 		}
+		// TODO(#218): This fallback logic will be removed when we refactor to follow
+		// the tmux command execution model. The shell field will be obsoleted and
+		// command will handle both string (shell execution) and array (direct execution).
 		// If no command is specified, use the shell if configured
 		if params.Shell != "" {
 			return params.Shell, nil

--- a/internal/core/agent/manager_test.go
+++ b/internal/core/agent/manager_test.go
@@ -229,6 +229,12 @@ func TestManager_GetDefaultCommand(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-existent agent")
 	}
+
+	// Test tmux agent without command
+	// Note: We can't use AddAgent with empty command due to schema validation,
+	// but we can test the error handling by mocking a scenario where
+	// GetTmuxParams returns empty command. This ensures the error message
+	// format is correct.
 }
 
 func TestManager_GetEnvironment(t *testing.T) {

--- a/internal/core/agent/manager_test.go
+++ b/internal/core/agent/manager_test.go
@@ -224,13 +224,10 @@ func TestManager_GetDefaultCommand(t *testing.T) {
 		t.Errorf("Expected command 'gpt', got '%s'", cmd)
 	}
 
-	// Test non-existent agent (should use agent ID)
-	cmd, err = manager.GetDefaultCommand("unknown")
-	if err != nil {
-		t.Fatalf("Failed to get default command: %v", err)
-	}
-	if cmd != "unknown" {
-		t.Errorf("Expected command 'unknown', got '%s'", cmd)
+	// Test non-existent agent (should return error)
+	_, err = manager.GetDefaultCommand("unknown")
+	if err == nil {
+		t.Error("Expected error for non-existent agent")
 	}
 }
 

--- a/internal/core/agent/manager_test.go
+++ b/internal/core/agent/manager_test.go
@@ -230,11 +230,9 @@ func TestManager_GetDefaultCommand(t *testing.T) {
 		t.Error("Expected error for non-existent agent")
 	}
 
-	// Test tmux agent without command
-	// Note: We can't use AddAgent with empty command due to schema validation,
-	// but we can test the error handling by mocking a scenario where
-	// GetTmuxParams returns empty command. This ensures the error message
-	// format is correct.
+	// Test tmux agent without command should fall back to shell or bash
+	// Note: Due to schema validation, we can't directly test with empty command,
+	// but the implementation now falls back to shell/bash instead of erroring.
 }
 
 func TestManager_GetEnvironment(t *testing.T) {

--- a/internal/core/config/types.go
+++ b/internal/core/config/types.go
@@ -65,7 +65,9 @@ type Agent struct {
 
 // TmuxParams contains tmux-specific session parameters
 type TmuxParams struct {
-	Command    string `yaml:"command"`
+	Command string `yaml:"command"`
+	// TODO(#218): The Shell field will be removed in favor of the tmux execution model.
+	// Command will accept either string (shell execution) or []string (direct execution).
 	Shell      string `yaml:"shell,omitempty"`
 	WindowName string `yaml:"windowName,omitempty"`
 	Detached   bool   `yaml:"detached,omitempty"`

--- a/internal/core/session/manager.go
+++ b/internal/core/session/manager.go
@@ -123,7 +123,7 @@ func (m *Manager) CreateSession(ctx context.Context, opts Options) (Session, err
 
 	// Set default command only if still not set
 	if opts.Command == "" {
-		opts.Command = "bash"
+		opts.Command = agent.DefaultShell
 	}
 
 	now := time.Now()

--- a/internal/core/session/manager.go
+++ b/internal/core/session/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) CreateSession(ctx context.Context, opts Options) (Session, err
 
 	// Set default agent ID if not provided
 	if opts.AgentID == "" {
-		opts.AgentID = "default"
+		opts.AgentID = agent.DefaultAgentID
 	}
 
 	// Get agent configuration if available

--- a/internal/core/session/manager.go
+++ b/internal/core/session/manager.go
@@ -101,10 +101,7 @@ func (m *Manager) CreateSession(ctx context.Context, opts Options) (Session, err
 		sessionID = GenerateID()
 	}
 
-	// Set defaults
-	if opts.Command == "" {
-		opts.Command = "bash"
-	}
+	// Set default agent ID if not provided
 	if opts.AgentID == "" {
 		opts.AgentID = "default"
 	}
@@ -114,7 +111,19 @@ func (m *Manager) CreateSession(ctx context.Context, opts Options) (Session, err
 	if m.agentManager != nil {
 		if agent, err := m.agentManager.GetAgent(opts.AgentID); err == nil {
 			agentConfig = agent
+
+			// If no command specified, try to get it from agent config
+			if opts.Command == "" && agent.Type == config.AgentTypeTmux {
+				if params, err := agent.GetTmuxParams(); err == nil && params.Command != "" {
+					opts.Command = params.Command
+				}
+			}
 		}
+	}
+
+	// Set default command only if still not set
+	if opts.Command == "" {
+		opts.Command = "bash"
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary

This PR fixes issue #203 where the agent name (e.g., "default") was being executed as a command in the tmux session instead of using the configured command from the agent's params.

## Problem

When running `amux run default` with a configured agent that has `command: bash` in its tmux params, the system was executing "default" as a command instead of "bash".

## Root Cause

1. `GetDefaultCommand` was returning the agent ID as a fallback when the command wasn't found
2. The session manager was setting a hardcoded "bash" default BEFORE loading the agent configuration
3. This caused the configured command to be ignored

## Solution

1. **Modified `GetDefaultCommand`** to return appropriate errors instead of falling back to the agent ID
2. **Updated session manager** to:
   - Load agent configuration first
   - Try to get the command from the agent's tmux params
   - Only fall back to "bash" if no command is found anywhere
3. **Updated tests** to expect the new error behavior

## Test Results

✅ Tested with the user's configuration file
✅ "bash" command is now correctly executed instead of "default"
✅ Session starts properly with the configured command
✅ All tests passing

Fixes #203