### PR TITLE
feat: add workspace protection with semaphore integration (Phase 1)

### DIFF
--- a/internal/core/workspace/manager_semaphore_test.go
+++ b/internal/core/workspace/manager_semaphore_test.go
@@ -1,0 +1,214 @@
+package workspace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/tests/helpers"
+)
+
+func TestManager_WorkspaceSemaphore(t *testing.T) {
+	// Create test repository
+	repoDir := helpers.CreateTestRepo(t)
+
+	// Initialize Amux
+	configManager := config.NewManager(repoDir)
+	cfg := config.DefaultConfig()
+	err := configManager.Save(cfg)
+	require.NoError(t, err)
+
+	// Create workspace manager
+	manager, err := workspace.NewManager(configManager)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create a test workspace
+	opts := workspace.CreateOptions{
+		Name:        "test-semaphore",
+		Description: "Test workspace for semaphore",
+	}
+	ws, err := manager.Create(ctx, opts)
+	require.NoError(t, err)
+
+	t.Run("AcquireAndRelease", func(t *testing.T) {
+		sessionID := "session-123"
+
+		// Acquire workspace
+		err := ws.Acquire(sessionID)
+		assert.NoError(t, err)
+
+		// Check session is listed
+		sessions, err := ws.SessionIDs()
+		assert.NoError(t, err)
+		assert.Contains(t, sessions, sessionID)
+
+		// Release workspace
+		err = ws.Release(sessionID)
+		assert.NoError(t, err)
+
+		// Check session is no longer listed
+		sessions, err = ws.SessionIDs()
+		assert.NoError(t, err)
+		assert.NotContains(t, sessions, sessionID)
+	})
+
+	t.Run("MultipleSessionsCanAcquire", func(t *testing.T) {
+		session1 := "session-001"
+		session2 := "session-002"
+
+		// Both sessions acquire
+		err := ws.Acquire(session1)
+		assert.NoError(t, err)
+		err = ws.Acquire(session2)
+		assert.NoError(t, err)
+
+		// Check both are listed
+		sessions, err := ws.SessionIDs()
+		assert.NoError(t, err)
+		assert.Len(t, sessions, 2)
+		assert.Contains(t, sessions, session1)
+		assert.Contains(t, sessions, session2)
+
+		// Release both
+		err = ws.Release(session1)
+		assert.NoError(t, err)
+		err = ws.Release(session2)
+		assert.NoError(t, err)
+	})
+
+	t.Run("SameSessionCannotAcquireTwice", func(t *testing.T) {
+		sessionID := "session-456"
+
+		// First acquire should succeed
+		err := ws.Acquire(sessionID)
+		assert.NoError(t, err)
+
+		// Second acquire should fail
+		err = ws.Acquire(sessionID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "already held")
+
+		// Clean up
+		err = ws.Release(sessionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("IsWorkspaceAvailable", func(t *testing.T) {
+		// Should be available initially
+		available, err := ws.IsAvailable()
+		assert.NoError(t, err)
+		assert.True(t, available)
+
+		// Acquire by one session - should still be available
+		sessionID := "session-789"
+		err = ws.Acquire(sessionID)
+		assert.NoError(t, err)
+
+		available, err = ws.IsAvailable()
+		assert.NoError(t, err)
+		assert.True(t, available) // Still has capacity
+
+		// Clean up
+		err = ws.Release(sessionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("RemoveWithSessionCheck", func(t *testing.T) {
+		// Create another workspace for removal test
+		opts2 := workspace.CreateOptions{
+			Name:        "test-remove-check",
+			Description: "Test workspace for removal check",
+		}
+		ws2, err := manager.Create(ctx, opts2)
+		require.NoError(t, err)
+
+		// Acquire by a session
+		sessionID := "session-remove"
+		err = ws2.Acquire(sessionID)
+		assert.NoError(t, err)
+
+		// Try to remove without force - should fail
+		err = manager.RemoveWithSessionCheck(ctx, workspace.Identifier(ws2.ID), false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "currently in use")
+
+		// Remove with force - should succeed
+		err = manager.RemoveWithSessionCheck(ctx, workspace.Identifier(ws2.ID), true)
+		assert.NoError(t, err)
+
+		// Verify workspace is removed
+		_, err = manager.Get(ctx, workspace.ID(ws2.ID))
+		assert.Error(t, err)
+	})
+
+	t.Run("WorkspaceWithNoSemaphore", func(t *testing.T) {
+		// Create workspace without any semaphore operations
+		opts3 := workspace.CreateOptions{
+			Name:        "test-no-semaphore",
+			Description: "Test workspace without semaphore",
+		}
+		ws3, err := manager.Create(ctx, opts3)
+		require.NoError(t, err)
+
+		// Check sessions - should return empty list
+		sessions, err := ws3.SessionIDs()
+		assert.NoError(t, err)
+		assert.Empty(t, sessions)
+
+		// Check availability - should be available
+		available, err := ws3.IsAvailable()
+		assert.NoError(t, err)
+		assert.True(t, available)
+
+		// Can remove without force
+		err = manager.RemoveWithSessionCheck(ctx, workspace.Identifier(ws3.ID), false)
+		assert.NoError(t, err)
+	})
+}
+
+func TestManager_WorkspaceSemaphoreEdgeCases(t *testing.T) {
+	// Create test repository
+	repoDir := helpers.CreateTestRepo(t)
+
+	// Initialize Amux
+	configManager := config.NewManager(repoDir)
+	cfg := config.DefaultConfig()
+	err := configManager.Save(cfg)
+	require.NoError(t, err)
+
+	// Create workspace manager
+	manager, err := workspace.NewManager(configManager)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("NonExistentWorkspace", func(t *testing.T) {
+		// Try RemoveWithSessionCheck on non-existent workspace
+		fakeID := "workspace-fake-123"
+
+		err := manager.RemoveWithSessionCheck(ctx, workspace.Identifier(fakeID), false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "workspace not found")
+	})
+
+	t.Run("ReleaseNonHeldSession", func(t *testing.T) {
+		// Create workspace
+		opts := workspace.CreateOptions{
+			Name:        "test-release-nonheld",
+			Description: "Test releasing non-held session",
+		}
+		ws, err := manager.Create(ctx, opts)
+		require.NoError(t, err)
+
+		// Try to release a session that never acquired
+		err = ws.Release("non-existent-session")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not held")
+	})
+}

--- a/internal/core/workspace/workspace.go
+++ b/internal/core/workspace/workspace.go
@@ -1,0 +1,137 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aki/amux/internal/semaphore"
+)
+
+// sessionHolder implements semaphore.Holder interface for session IDs
+type sessionHolder struct {
+	sessionID string
+}
+
+func (h *sessionHolder) ID() string {
+	return h.sessionID
+}
+
+// getSemaphorePath returns the path to the workspace semaphore file
+func (w *Workspace) getSemaphorePath() string {
+	// Semaphore is stored in the workspace directory, not in the worktree
+	// Extract workspace directory from the worktree path
+	workspaceDir := filepath.Dir(w.Path) // Remove "worktree" from path
+	return filepath.Join(workspaceDir, "semaphore.json")
+}
+
+// Acquire acquires the workspace semaphore for a session
+func (w *Workspace) Acquire(sessionID string) error {
+	semaphorePath := w.getSemaphorePath()
+
+	// Create semaphore with capacity 10 (reasonable limit for concurrent sessions)
+	sem, err := semaphore.New(semaphorePath, 10)
+	if err != nil {
+		return fmt.Errorf("failed to create semaphore: %w", err)
+	}
+	defer func() {
+		_ = sem.Close()
+	}()
+
+	// Acquire semaphore
+	holder := &sessionHolder{sessionID: sessionID}
+	if err := sem.Acquire(holder); err != nil {
+		return fmt.Errorf("failed to acquire workspace: %w", err)
+	}
+
+	return nil
+}
+
+// Release releases the workspace semaphore for a session
+func (w *Workspace) Release(sessionID string) error {
+	semaphorePath := w.getSemaphorePath()
+
+	// Create semaphore
+	sem, err := semaphore.New(semaphorePath, 10)
+	if err != nil {
+		return fmt.Errorf("failed to create semaphore: %w", err)
+	}
+	defer func() {
+		_ = sem.Close()
+	}()
+
+	// Release semaphore
+	if err := sem.Release(sessionID); err != nil {
+		return fmt.Errorf("failed to release workspace: %w", err)
+	}
+
+	return nil
+}
+
+// SessionIDs returns the list of session IDs currently using the workspace
+func (w *Workspace) SessionIDs() ([]string, error) {
+	semaphorePath := w.getSemaphorePath()
+
+	// Check if semaphore file exists
+	if _, err := os.Stat(semaphorePath); os.IsNotExist(err) {
+		// No semaphore file means no sessions are using it
+		return []string{}, nil
+	}
+
+	// Create semaphore
+	sem, err := semaphore.New(semaphorePath, 10)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create semaphore: %w", err)
+	}
+	defer func() {
+		_ = sem.Close()
+	}()
+
+	// Get holders
+	return sem.Holders(), nil
+}
+
+// IsAvailable checks if the workspace has available capacity
+func (w *Workspace) IsAvailable() (bool, error) {
+	semaphorePath := w.getSemaphorePath()
+
+	// Check if semaphore file exists
+	if _, err := os.Stat(semaphorePath); os.IsNotExist(err) {
+		// No semaphore file means it's available
+		return true, nil
+	}
+
+	// Create semaphore
+	sem, err := semaphore.New(semaphorePath, 10)
+	if err != nil {
+		return false, fmt.Errorf("failed to create semaphore: %w", err)
+	}
+	defer func() {
+		_ = sem.Close()
+	}()
+
+	// Check if there's available capacity
+	return sem.Available() > 0, nil
+}
+
+// SessionCount returns the number of active sessions using the workspace
+func (w *Workspace) SessionCount() int {
+	semaphorePath := w.getSemaphorePath()
+
+	// Check if semaphore file exists
+	if _, err := os.Stat(semaphorePath); os.IsNotExist(err) {
+		// No semaphore file means no sessions
+		return 0
+	}
+
+	// Create semaphore
+	sem, err := semaphore.New(semaphorePath, 10)
+	if err != nil {
+		return 0
+	}
+	defer func() {
+		_ = sem.Close()
+	}()
+
+	return sem.Count()
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the workspace protection feature, which prevents deletion of workspaces that are currently in use by active sessions. This is achieved using the existing file-based semaphore library.

## Changes

- Added semaphore methods directly to the `Workspace` struct for better encapsulation:
  - `Acquire(sessionID)`: Mark workspace as in use by a session
  - `Release(sessionID)`: Release workspace when session ends
  - `SessionIDs()`: Get list of sessions using the workspace
  - `IsAvailable()`: Check if workspace has capacity for more sessions
  - `SessionCount()`: Get number of active sessions
- Added `RemoveWithSessionCheck` to Manager for safe workspace removal with `--force` option
- Comprehensive test coverage for all semaphore operations

## Design Decision

After initial implementation, we moved the semaphore methods from `Manager` to `Workspace` struct because:
- The semaphore file is stored within the workspace directory structure
- The semaphore library already encapsulates the implementation details
- This provides a more natural and object-oriented API

## Test Plan

- [x] Unit tests for all new methods
- [x] Test coverage for edge cases (non-existent workspace, multiple sessions, etc.)
- [x] All existing tests pass
- [ ] Manual testing with real sessions (will be done in Phase 2)

## Future Phases

This is Phase 1 of 4:
- **Phase 2**: Integrate with session state machine to automatically acquire/release workspaces
- **Phase 3**: Update CLI commands with protection warnings and `--force` flag
- **Phase 4**: Add end-to-end integration tests

Related to workspace protection design in `.amux/workspaces/workspace-feat-workspace-prote-1750762876-8944e211/storage/DESIGN.md`