### PR TITLE
feat: add CLI updates for workspace protection

### DIFF
--- a/internal/cli/commands/workspace/remove_test.go
+++ b/internal/cli/commands/workspace/remove_test.go
@@ -1,0 +1,82 @@
+package workspace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aki/amux/internal/core/config"
+	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/tests/helpers"
+)
+
+func TestWorkspaceSessionProtection(t *testing.T) {
+	// Create test repository
+	repoDir := helpers.CreateTestRepo(t)
+
+	// Initialize Amux
+	configManager := config.NewManager(repoDir)
+	cfg := config.DefaultConfig()
+	err := configManager.Save(cfg)
+	require.NoError(t, err)
+
+	// Create workspace manager
+	wsManager, err := workspace.NewManager(configManager)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("CannotRemoveWorkspaceWithActiveSessions", func(t *testing.T) {
+		// Create a test workspace
+		ws, err := wsManager.Create(ctx, workspace.CreateOptions{
+			Name:        "test-remove-protected",
+			Description: "Test workspace for protection",
+		})
+		require.NoError(t, err)
+
+		// Simulate an active session by acquiring the semaphore
+		fakeSessionID := "test-session-123"
+		err = ws.Acquire(fakeSessionID)
+		require.NoError(t, err)
+
+		// Try to remove without force using RemoveWithSessionCheck
+		err = wsManager.RemoveWithSessionCheck(ctx, workspace.Identifier(ws.ID), false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "currently in use")
+
+		// Verify workspace still exists
+		exists, err := wsManager.Get(ctx, workspace.ID(ws.ID))
+		assert.NoError(t, err)
+		assert.NotNil(t, exists)
+
+		// Clean up
+		err = ws.Release(fakeSessionID)
+		assert.NoError(t, err)
+		err = wsManager.Remove(ctx, workspace.Identifier(ws.ID), workspace.RemoveOptions{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CanForceRemoveWorkspaceWithActiveSessions", func(t *testing.T) {
+		// Create a test workspace
+		ws, err := wsManager.Create(ctx, workspace.CreateOptions{
+			Name:        "test-force-remove",
+			Description: "Test workspace for force removal",
+		})
+		require.NoError(t, err)
+
+		// Simulate an active session by acquiring the semaphore
+		fakeSessionID := "test-session-456"
+		err = ws.Acquire(fakeSessionID)
+		require.NoError(t, err)
+
+		// Force remove should succeed
+		err = wsManager.RemoveWithSessionCheck(ctx, workspace.Identifier(ws.ID), true)
+		assert.NoError(t, err)
+
+		// Verify workspace no longer exists
+		_, err = wsManager.Get(ctx, workspace.ID(ws.ID))
+		assert.Error(t, err)
+	})
+}

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -163,7 +163,7 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 	}
 
 	// Create table
-	tbl := NewTable("ID", "NAME", "BRANCH", "SESSIONS", "AGE", "STATUS", "DESCRIPTION")
+	tbl := NewTable("ID", "NAME", "BRANCH", "AGE", "STATUS", "DESCRIPTION")
 
 	// Add rows
 	for _, w := range workspaces {
@@ -177,8 +177,11 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 			description = "-"
 		}
 
-		// Format status with appropriate icon
+		// Format status with appropriate icon and session info
 		var status string
+		sessionCount := w.SessionCount()
+
+		// Base status
 		switch w.Status {
 		case workspace.StatusConsistent:
 			status = SuccessStyle.Render("✓ ok")
@@ -192,10 +195,17 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 			status = DimStyle.Render("unknown")
 		}
 
-		// Get session count
-		sessions := fmt.Sprintf("%d", w.SessionCount())
+		// Add session info if any sessions are active
+		if sessionCount > 0 {
+			sessionInfo := fmt.Sprintf("%d active", sessionCount)
+			// Highlight if 3 or more sessions
+			if sessionCount >= 3 {
+				sessionInfo = WarningStyle.Render(sessionInfo)
+			}
+			status = fmt.Sprintf("%s • %s", status, sessionInfo)
+		}
 
-		tbl.AddRow(id, w.Name, w.Branch, sessions, age, status, description)
+		tbl.AddRow(id, w.Name, w.Branch, age, status, description)
 	}
 
 	// Print with header

--- a/internal/cli/ui/output.go
+++ b/internal/cli/ui/output.go
@@ -123,6 +123,22 @@ func PrintWorkspace(w *workspace.Workspace) {
 		statusStr = DimStyle.Render("Unknown")
 	}
 	OutputLine("   %s %s", DimStyle.Render("Status:"), statusStr)
+
+	// Show active sessions
+	sessionCount := w.SessionCount()
+	if sessionCount > 0 {
+		sessionIDs, err := w.SessionIDs()
+		if err == nil && len(sessionIDs) > 0 {
+			OutputLine("   %s %d active session(s):", DimStyle.Render("Sessions:"), sessionCount)
+			for _, sessionID := range sessionIDs {
+				OutputLine("     - %s", sessionID)
+			}
+		} else {
+			OutputLine("   %s %d", DimStyle.Render("Sessions:"), sessionCount)
+		}
+	} else {
+		OutputLine("   %s %s", DimStyle.Render("Sessions:"), DimStyle.Render("none"))
+	}
 }
 
 // FormatDuration formats a duration into a human-readable string
@@ -147,7 +163,7 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 	}
 
 	// Create table
-	tbl := NewTable("ID", "NAME", "BRANCH", "AGE", "STATUS", "DESCRIPTION")
+	tbl := NewTable("ID", "NAME", "BRANCH", "SESSIONS", "AGE", "STATUS", "DESCRIPTION")
 
 	// Add rows
 	for _, w := range workspaces {
@@ -176,7 +192,10 @@ func PrintWorkspaceList(workspaces []*workspace.Workspace) {
 			status = DimStyle.Render("unknown")
 		}
 
-		tbl.AddRow(id, w.Name, w.Branch, age, status, description)
+		// Get session count
+		sessions := fmt.Sprintf("%d", w.SessionCount())
+
+		tbl.AddRow(id, w.Name, w.Branch, sessions, age, status, description)
 	}
 
 	// Print with header


### PR DESCRIPTION
## Summary
- Add CLI protection to prevent removal of workspaces with active sessions
- Show active session counts in workspace listings
- Add `--force` flag to override protection when needed
- **UPDATE**: Merged SESSIONS column into STATUS column to save horizontal space and group related information

## Changes
1. **Workspace removal protection**:
   - Check for active sessions before removing workspace
   - Show detailed error with session list when blocked
   - Add `--force` flag to override protection

2. **Session visibility in CLI**:
   - ~~Add SESSIONS column to `amux ws list` output~~
   - **NEW**: Display session count as part of STATUS column (e.g., "✓ ok • 2 active")
   - Highlight with warning color when 3+ sessions are active
   - Show session details in `amux ws show` command

3. **Tests**:
   - Add comprehensive tests for workspace protection
   - Test force removal functionality
   - Ensure backward compatibility

## Test plan
- [x] Run `amux ws list` - verify session counts are shown in STATUS column
- [x] Create sessions in a workspace, try to remove it - verify protection works
- [x] Use `--force` flag - verify it overrides protection
- [x] Run `amux ws show <workspace>` - verify session details are displayed
- [x] All tests pass (`just test`)