### PR TITLE
feat: improve storage list display formatting

### DIFF
--- a/internal/core/storage/types.go
+++ b/internal/core/storage/types.go
@@ -9,10 +9,12 @@ type Provider interface {
 
 // FileInfo represents information about a file or directory
 type FileInfo struct {
-	Name    string
-	Size    int64
-	IsDir   bool
-	ModTime time.Time
+	Name       string
+	Size       int64
+	IsDir      bool
+	IsSymlink  bool
+	LinkTarget string // Only set if IsSymlink is true
+	ModTime    time.Time
 }
 
 // ListResult represents the result of a list operation


### PR DESCRIPTION
## Summary
- Improved the visual formatting of `amux ws storage list` and `amux session storage list` commands
- Made file listings more readable and informative

## Changes
- Added table format for file listings with NAME, TYPE, SIZE columns
- Moved "Total: X items" to the top for better visibility
- Added symlink detection and display with target paths
- Shortened long symlink targets (>50 chars) for better readability
- Used human-readable file sizes (B, KB, MB, GB) instead of raw bytes
- Distinguished between files, directories, and symlinks clearly

## Test plan
- [x] Tested `amux ws storage list` with regular files
- [x] Tested with directories
- [x] Tested with symlinks pointing to directories
- [x] Tested with long symlink paths
- [x] All tests pass (`just test`)