### PR TITLE
fix: change default log level to warn

### DIFF
--- a/internal/cli/commands/logger.go
+++ b/internal/cli/commands/logger.go
@@ -17,7 +17,7 @@ var (
 
 // RegisterLoggerFlags registers global logging flags
 func RegisterLoggerFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&flagLogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	cmd.PersistentFlags().StringVar(&flagLogLevel, "log-level", "warn", "Log level (debug, info, warn, error)")
 	cmd.PersistentFlags().StringVar(&flagLogFormat, "log-format", "text", "Log format (text, json)")
 	cmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "Enable debug logging (shortcut for --log-level debug)")
 }


### PR DESCRIPTION
## Summary
- Changed default log level from 'info' to 'warn' to reduce noise in normal operation
- Users will now only see warning and error messages by default
- Info/debug messages require explicit --log-level flag

## Test plan
- [x] Build and run tests
- [x] Verified default behavior shows no logs: `amux ws list`, `amux ps`
- [x] Verified --log-level info shows state transition logs: `amux --log-level info run claude`
- [x] All existing tests pass