### PR TITLE
fix: remove unnecessary empty lines before command output

### DIFF
--- a/internal/cli/commands/session/list.go
+++ b/internal/cli/commands/session/list.go
@@ -132,7 +132,6 @@ func listSessions(cmd *cobra.Command, args []string) error {
 	// Print with header
 	ui.PrintSectionHeader("🤖", "Active Sessions", len(sessions))
 	tbl.Print()
-	ui.OutputLine("")
 
 	return nil
 }

--- a/internal/cli/ui/table.go
+++ b/internal/cli/ui/table.go
@@ -30,5 +30,5 @@ func NewTable(headers ...interface{}) table.Table {
 
 // PrintSectionHeader prints a consistent section header
 func PrintSectionHeader(icon string, title string, count int) {
-	OutputLine("\n%s %s (%d)", icon, title, count)
+	OutputLine("%s %s (%d)", icon, title, count)
 }


### PR DESCRIPTION
## Summary

- Remove leading newline from `PrintSectionHeader` function
- Remove extra empty line after session list table
- Fix output formatting for storage list commands (improved by linter)

## Changes

This PR removes the unnecessary empty lines that were appearing before command output in:
- `amux ws list`
- `amux ps` / `amux session list` / `amux status`
- `amux workspace storage list`
- `amux session storage list`

### Before
```
❯ amux ws ls

📋 Workspaces (5)
```

### After
```
❯ amux ws ls
📋 Workspaces (5)
```

## Test plan

- [x] Build the project with `just build`
- [x] Test `amux ws list` - no empty line before output
- [x] Test `amux ps` / `amux status` - no empty line before output
- [x] Test storage list commands - no empty line before output
- [x] All tests pass with `just test`