### PR TITLE
fix: increase timeout in executor test to prevent flaky failures

### DIFF
--- a/internal/core/hooks/executor_test.go
+++ b/internal/core/hooks/executor_test.go
@@ -123,7 +123,7 @@ func TestExecutor_ExecuteHooks(t *testing.T) {
 		hook := hooks.Hook{
 			Name:    "Env test",
 			Script:  scriptPath,
-			Timeout: "1s",
+			Timeout: "5s", // Increase timeout to avoid flaky failures on first run
 			OnError: hooks.ErrorStrategyFail,
 			Env: map[string]string{
 				"TEST_VAR": "test_value",


### PR DESCRIPTION
## Summary
- Increased timeout from 1s to 5s in the "uses environment variables" test to avoid flaky failures on first run
- This fixes the "signal: killed" error that occurs when the shell script takes longer to start on the first run

## Test plan
- [x] Run the executor tests multiple times to ensure they pass consistently
- [x] Verify that the increased timeout doesn't negatively impact test performance
- [x] Confirm all other tests continue to pass