### PR TITLE
test: set log level to warn in tests to match CLI default

### DIFF
--- a/internal/cli/commands/session/remove_test.go
+++ b/internal/cli/commands/session/remove_test.go
@@ -14,8 +14,14 @@ import (
 	"github.com/aki/amux/internal/core/config"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/test"
 	"github.com/aki/amux/internal/tests/helpers"
 )
+
+func TestMain(m *testing.M) {
+	test.InitTestLogger()
+	os.Exit(m.Run())
+}
 
 func TestRemoveSession(t *testing.T) {
 	// Skip if tmux is not available

--- a/internal/core/session/failure_test.go
+++ b/internal/core/session/failure_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aki/amux/internal/core/idmap"
 	"github.com/aki/amux/internal/core/session/state"
 	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/test"
 )
 
 // MockProcessChecker implements process.Checker for testing
@@ -36,6 +37,11 @@ func (m *MockProcessChecker) HasChildren(pid int) (bool, error) {
 
 func (m *MockProcessChecker) SetHasChildren(pid int, hasChildren bool) {
 	m.hasChildren[pid] = hasChildren
+}
+
+func TestMain(m *testing.M) {
+	test.InitTestLogger()
+	os.Exit(m.Run())
 }
 
 func TestSessionFailureDetection(t *testing.T) {

--- a/internal/core/session/orphaned_session.go
+++ b/internal/core/session/orphaned_session.go
@@ -27,7 +27,7 @@ func CreateOrphanedSession(ctx context.Context, info *Info, manager *Manager, re
 		return nil, fmt.Errorf("CreateOrphanedSession: StateDir is required")
 	}
 
-	s.Manager = state.InitManager(info.ID, info.WorkspaceID, info.StateDir, nil)
+	s.Manager = state.InitManager(info.ID, info.WorkspaceID, info.StateDir)
 
 	// Set to orphaned state
 	if err := s.TransitionTo(ctx, state.StatusOrphaned); err != nil {

--- a/internal/core/session/state/manager_test.go
+++ b/internal/core/session/state/manager_test.go
@@ -2,14 +2,21 @@ package state
 
 import (
 	"context"
-	"log/slog"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/aki/amux/internal/test"
 )
+
+func TestMain(m *testing.M) {
+	test.InitTestLogger()
+	os.Exit(m.Run())
+}
 
 func TestManager_CurrentState(t *testing.T) {
 	tmpDir := t.TempDir()
-	manager := InitManager("session-123", "workspace-456", tmpDir, slog.Default())
+	manager := InitManager("session-123", "workspace-456", tmpDir)
 
 	// Test default state (no file exists)
 	state, err := manager.CurrentState()
@@ -78,7 +85,7 @@ func TestManager_TransitionTo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			manager := InitManager("session-123", "workspace-456", tmpDir, slog.Default())
+			manager := InitManager("session-123", "workspace-456", tmpDir)
 
 			// Set initial state if not created
 			if tt.initialState != StatusCreated {
@@ -132,7 +139,7 @@ func TestManager_TransitionTo(t *testing.T) {
 
 func TestManager_StateChangeHandlers(t *testing.T) {
 	tmpDir := t.TempDir()
-	manager := InitManager("session-123", "workspace-456", tmpDir, slog.Default())
+	manager := InitManager("session-123", "workspace-456", tmpDir)
 
 	// Track handler calls
 	handlerCalls := make([]string, 0)
@@ -174,12 +181,12 @@ func TestManager_StatePersistence(t *testing.T) {
 	// Test with nil logger (should use default)
 
 	// Create first manager and set state
-	manager1 := InitManager("session-123", "workspace-456", tmpDir, nil)
+	manager1 := InitManager("session-123", "workspace-456", tmpDir)
 	_ = manager1.TransitionTo(context.Background(), StatusStarting)
 	_ = manager1.TransitionTo(context.Background(), StatusRunning)
 
 	// Create second manager with same paths
-	manager2 := InitManager("session-123", "workspace-456", tmpDir, nil)
+	manager2 := InitManager("session-123", "workspace-456", tmpDir)
 
 	// Verify state is persisted
 	state, err := manager2.CurrentState()
@@ -194,7 +201,7 @@ func TestManager_StatePersistence(t *testing.T) {
 
 func TestManager_ConcurrentAccess(t *testing.T) {
 	tmpDir := t.TempDir()
-	manager := InitManager("session-123", "workspace-456", tmpDir, slog.Default())
+	manager := InitManager("session-123", "workspace-456", tmpDir)
 
 	// Run concurrent transitions
 	done := make(chan bool, 3)

--- a/internal/core/session/tmux_session.go
+++ b/internal/core/session/tmux_session.go
@@ -69,8 +69,8 @@ func CreateTmuxSession(ctx context.Context, info *Info, manager *Manager, tmuxAd
 		return nil, fmt.Errorf("CreateTmuxSession: StateDir is required")
 	}
 
-	// Initialize state manager with default slog logger
-	s.Manager = state.InitManager(info.ID, info.WorkspaceID, info.StateDir, nil)
+	// Initialize state manager
+	s.Manager = state.InitManager(info.ID, info.WorkspaceID, info.StateDir)
 
 	// Add semaphore handler if workspace manager is available
 	if manager != nil && manager.workspaceManager != nil {

--- a/internal/core/tail/tail_test.go
+++ b/internal/core/tail/tail_test.go
@@ -3,6 +3,7 @@ package tail_test
 import (
 	"bytes"
 	"context"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -16,8 +17,14 @@ import (
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/tail"
 	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/test"
 	"github.com/aki/amux/internal/tests/helpers"
 )
+
+func TestMain(m *testing.M) {
+	test.InitTestLogger()
+	os.Exit(m.Run())
+}
 
 // writerFunc is an adapter to allow the use of ordinary functions as io.Writer
 type writerFunc struct {

--- a/internal/mcp/session_tools_test.go
+++ b/internal/mcp/session_tools_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,7 +12,13 @@ import (
 	"github.com/aki/amux/internal/adapters/tmux"
 	"github.com/aki/amux/internal/core/session"
 	"github.com/aki/amux/internal/core/workspace"
+	"github.com/aki/amux/internal/test"
 )
+
+func TestMain(m *testing.M) {
+	test.InitTestLogger()
+	os.Exit(m.Run())
+}
 
 func TestSessionRun(t *testing.T) {
 	// Skip if tmux not available

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/aki/amux/internal/tests/helpers"
 )
 
+func TestMain(m *testing.M) {
+	InitTestLogger()
+	os.Exit(m.Run())
+}
+
 func TestIntegration_FullWorkflow(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+)
+
+var initOnce sync.Once
+
+// InitTestLogger initializes the logger for tests with warn level to match CLI default
+func InitTestLogger() {
+	initOnce.Do(func() {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelWarn,
+		})))
+	})
+}


### PR DESCRIPTION
## Summary

This PR updates the test environment to use the same default log level (`warn`) as the CLI, preventing INFO logs from appearing during test runs.

## Changes

- Add `InitTestLogger` helper function to set slog default level to warn
- Add `TestMain` to test packages to initialize logger once per package
- Remove logger parameter from `state.InitManager` and use global slog functions
- Update all test files to use the centralized test logger initialization

## Test plan

- [x] Run `just test` and verify no INFO/DEBUG logs appear
- [x] Verify all tests pass
- [x] Check that production code still logs correctly

## Related

This complements the CLI default log level change that was already merged in #231.